### PR TITLE
feat: Enable PCECommunityToken to be upgraded using Beacon proxy pattern (2/2)

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -15,7 +15,11 @@
   solc = "0.8.26"
   src = "src"
   test = "test"
-libs = ["node_modules", "lib"]
+  libs = ["node_modules", "lib"]
+  ffi = true
+  ast = true
+  build_info = true
+  extra_output = ["storageLayout"]
 
 [profile.ci]
   fuzz = { runs = 10_000 }

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "@openzeppelin/contracts": "^5.0.1",
+    "@openzeppelin/upgrades-core": "^1.34.4",
     "prettier-plugin-solidity": "^1.3.1"
   },
   "devDependencies": {

--- a/remappings.txt
+++ b/remappings.txt
@@ -1,4 +1,4 @@
 @openzeppelin/contracts/=node_modules/@openzeppelin/contracts/
-forge-std/=node_modules/forge-std/
+forge-std/=node_modules/forge-std/src/
 @openzeppelin/contracts/=lib/openzeppelin-contracts-upgradeable/lib/openzeppelin-contracts/contracts/
 @openzeppelin/contracts-upgradeable/=lib/openzeppelin-contracts-upgradeable/contracts/

--- a/script/Base.s.sol
+++ b/script/Base.s.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.26 <0.9.0;
 
-import { Script } from "forge-std/src/Script.sol";
+import { Script } from "forge-std/Script.sol";
 
 abstract contract BaseScript is Script {
     /// @dev Included to enable compilation of the script without a $MNEMONIC environment variable.

--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -6,23 +6,30 @@ import { PCECommunityToken } from "../src/PCECommunityToken.sol";
 
 import { BaseScript } from "./Base.s.sol";
 
-import { console2 } from "forge-std/src/console2.sol";
+import { console2 } from "forge-std/console2.sol";
+import { Upgrades } from "openzeppelin-foundry-upgrades/Upgrades.sol";
 
 /// @dev See the Solidity Scripting tutorial: https://book.getfoundry.sh/tutorials/solidity-scripting
 contract Deploy is BaseScript {
-    function run() public broadcast returns (PCEToken pceToken, PCECommunityToken pceCommunityToken) {
-        pceCommunityToken = new PCECommunityToken();
+    function run() public broadcast returns (address, address) {
+        PCECommunityToken pceCommunityToken = new PCECommunityToken();
+        address pceCommunityTokenAddress = address(pceCommunityToken);
 
-        pceToken = new PCEToken();
         // mainnet: https://github.com/maticnetwork/static/blob/master/network/mainnet/v1/index.json
         // 0xa40fc0782bee28dd2cf8cb4ac2ecdb05c537f1b5
         // amoy: https://github.com/maticnetwork/static/blob/master/network/testnet/amoy/index.json
         // 0x687C1D2dd0F422421BeF7aC2a52f50e858CAA867
-        pceToken.initialize(
-            "PCE Token", "PCE", address(pceCommunityToken), 0x687C1D2dd0F422421BeF7aC2a52f50e858CAA867
+        address pceTokenAddress = Upgrades.deployUUPSProxy(
+            "PCEToken.sol:PCEToken",
+            abi.encodeCall(
+                PCEToken.initialize,
+                ("PCE Token", "PCE", pceCommunityTokenAddress, 0x687C1D2dd0F422421BeF7aC2a52f50e858CAA867)
+            )
         );
 
-        console2.log("PCE Token deployed at", address(pceToken));
-        console2.log("PCE Community Token deployed at", address(pceCommunityToken));
+        console2.log("PCE Community Token deployed at", pceCommunityTokenAddress);
+        console2.log("PCE Token deployed at", pceTokenAddress);
+
+        return (pceCommunityTokenAddress, pceTokenAddress);
     }
 }

--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -9,11 +9,12 @@ import { BaseScript } from "./Base.s.sol";
 import { console2 } from "forge-std/console2.sol";
 import { Upgrades } from "openzeppelin-foundry-upgrades/Upgrades.sol";
 
+import { UpgradeableBeacon } from "@openzeppelin/contracts/proxy/beacon/UpgradeableBeacon.sol";
+
 /// @dev See the Solidity Scripting tutorial: https://book.getfoundry.sh/tutorials/solidity-scripting
 contract Deploy is BaseScript {
     function run() public broadcast returns (address, address) {
-        PCECommunityToken pceCommunityToken = new PCECommunityToken();
-        address pceCommunityTokenAddress = address(pceCommunityToken);
+        address pceCommunityTokenAddress = Upgrades.deployBeacon("PCECommunityToken.sol:PCECommunityToken", broadcaster);
 
         // mainnet: https://github.com/maticnetwork/static/blob/master/network/mainnet/v1/index.json
         // 0xa40fc0782bee28dd2cf8cb4ac2ecdb05c537f1b5

--- a/script/Upgrade.s.sol
+++ b/script/Upgrade.s.sol
@@ -8,8 +8,10 @@ import { Upgrades } from "openzeppelin-foundry-upgrades/Upgrades.sol";
 /// @dev See the Solidity Scripting tutorial: https://book.getfoundry.sh/tutorials/solidity-scripting
 contract Upgrade is BaseScript {
     function run() public broadcast {
-        address pceTokenAddress = 0x3Aa5ebB10DC797CAC828524e59A333d0A371443c;
+        address pceTokenAddress = 0x70e0bA845a1A0F2DA3359C97E0285013525FFC49;
+        address pceCommunityTokenAddress = 0x95401dc811bb5740090279Ba06cfA8fcF6113778;
 
         Upgrades.upgradeProxy(pceTokenAddress, "PCETokenV2.sol:PCETokenV2", "");
+        Upgrades.upgradeBeacon(pceCommunityTokenAddress, "PCECommunityTokenV2.sol:PCECommunityTokenV2");
     }
 }

--- a/script/Upgrade.s.sol
+++ b/script/Upgrade.s.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.26 <0.9.0;
+
+import { BaseScript } from "./Base.s.sol";
+
+import { Upgrades } from "openzeppelin-foundry-upgrades/Upgrades.sol";
+
+/// @dev See the Solidity Scripting tutorial: https://book.getfoundry.sh/tutorials/solidity-scripting
+contract Upgrade is BaseScript {
+    function run() public broadcast {
+        address pceTokenAddress = 0x3Aa5ebB10DC797CAC828524e59A333d0A371443c;
+
+        Upgrades.upgradeProxy(pceTokenAddress, "PCETokenV2.sol:PCETokenV2", "");
+    }
+}

--- a/src/PCECommunityToken.sol
+++ b/src/PCECommunityToken.sol
@@ -12,7 +12,7 @@ import { EIP3009 } from "./lib/EIP3009.sol";
 import { TokenSetting } from "./lib/TokenSetting.sol";
 import { ExchangeAllowMethod } from "./lib/Enum.sol";
 
-import { console2 } from "forge-std/src/console2.sol";
+import { console2 } from "forge-std/console2.sol";
 
 contract PCECommunityToken is
     Initializable,
@@ -461,5 +461,9 @@ contract PCECommunityToken is
 
         return
             rawBalanceToDisplayBalance(accountInfo.midnightBalance * pceToken.swapableToPCEIndividualRate() / BP_BASE);
+    }
+
+    function version() public pure returns (string memory) {
+        return "1.0.0";
     }
 }

--- a/src/PCECommunityTokenV2.sol
+++ b/src/PCECommunityTokenV2.sol
@@ -1,0 +1,463 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import { ERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol";
+import { ERC20BurnableUpgradeable } from
+    "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC20BurnableUpgradeable.sol";
+import { Initializable } from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import { OwnableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import { PCEToken } from "./PCEToken.sol";
+import { Utils } from "./lib/Utils.sol";
+import { EIP3009 } from "./lib/EIP3009.sol";
+import { TokenSetting } from "./lib/TokenSetting.sol";
+import { ExchangeAllowMethod } from "./lib/Enum.sol";
+
+import { console2 } from "forge-std/console2.sol";
+
+/// @custom:oz-upgrades-from PCECommunityToken
+
+contract PCECommunityTokenV2 is
+    Initializable,
+    ERC20Upgradeable,
+    ERC20BurnableUpgradeable,
+    OwnableUpgradeable,
+    EIP3009,
+    TokenSetting
+{
+    uint256 public constant INITIAL_FACTOR = 10 ** 18;
+    uint16 public constant BP_BASE = 10_000;
+    uint16 public constant MAX_CHARACTER_LENGTH = 10;
+
+    address public pceAddress;
+    uint256 public initialFactor;
+    uint256 public epochTime;
+    uint256 public lastModifiedFactor;
+
+    struct AccountInfo {
+        uint256 midnightBalance;
+        uint256 firstTransactionTime;
+        uint256 lastModifiedMidnightBalanceTime;
+        uint256 mintArigatoCreationToday;
+    }
+
+    mapping(address user => AccountInfo accountInfo) private _accountInfos;
+
+    event PCETransfer(address indexed from, address indexed to, uint256 displayAmount, uint256 rawAmount);
+    event MintArigatoCreation(address indexed to, uint256 displayAmount, uint256 rawAmount);
+    event MetaTransactionFeeCollected(address indexed from, address indexed to, uint256 displayFee, uint256 rawFee);
+
+    function initialize() public initializer { }
+
+    function getCurrentFactor() public view returns (uint256) {
+        if (lastModifiedFactor == 0) {
+            return 0;
+        }
+        if (decreaseIntervalDays == 0) {
+            return lastModifiedFactor;
+        }
+        if (intervalDaysOf(lastDecreaseTime, block.timestamp, decreaseIntervalDays)) {
+            return lastModifiedFactor * afterDecreaseBp / BP_BASE;
+        } else {
+            return lastModifiedFactor;
+        }
+    }
+
+    function updateFactorIfNeeded() public {
+        if (lastDecreaseTime == block.timestamp) {
+            return;
+        }
+
+        PCEToken pceToken = PCEToken(pceAddress);
+        pceToken.updateFactorIfNeeded();
+
+        uint256 currentFactor = getCurrentFactor();
+        if (currentFactor != lastModifiedFactor) {
+            lastModifiedFactor = currentFactor;
+            lastDecreaseTime = block.timestamp;
+        }
+    }
+
+    function rawBalanceToDisplayBalance(uint256 rawBalance) public view returns (uint256) {
+        uint256 currentFactor = getCurrentFactor();
+        if (currentFactor < 1) {
+            currentFactor = 1;
+        }
+        return rawBalance / currentFactor;
+    }
+
+    function displayBalanceToRawBalance(uint256 displayBalance) public view returns (uint256) {
+        uint256 currentFactor = getCurrentFactor();
+        if (currentFactor < 1) {
+            currentFactor = 1;
+        }
+        return displayBalance * currentFactor;
+    }
+
+    function totalSupply() public view override returns (uint256) {
+        return rawBalanceToDisplayBalance(super.totalSupply());
+    }
+
+    function balanceOf(address account) public view override returns (uint256) {
+        return rawBalanceToDisplayBalance(super.balanceOf(account));
+    }
+
+    function _update(address from, address to, uint256 value) internal override {
+        _beforeTokenTransfer(from, to, value);
+        super._update(from, to, value);
+        _afterTokenTransfer(from, to, value);
+    }
+
+    function _beforeTokenTransfer(address from, address to, uint256 amount) internal {
+        if (midnightTotalSupplyModifiedTime == 0) {
+            midnightTotalSupply = amount;
+            midnightTotalSupplyModifiedTime = block.timestamp;
+        } else if (intervalDaysOf(midnightTotalSupplyModifiedTime, block.timestamp, 1)) {
+            midnightTotalSupply = super.totalSupply();
+            midnightTotalSupplyModifiedTime = block.timestamp;
+            // Reset arigatoCreateionMintToday, but set it to 1 instead of 0 to reduce gas consumption
+            mintArigatoCreationToday = 1;
+            mintArigatoCreationTodayForGuest = 1;
+        }
+        if (from != address(0)) {
+            _beforeTokenTransferAtAddress(from);
+        }
+        if (to != address(0)) {
+            _beforeTokenTransferAtAddress(to);
+        }
+    }
+
+    function _beforeTokenTransferAtAddress(address account) internal {
+        if (_accountInfos[account].firstTransactionTime == 0) {
+            _accountInfos[account].firstTransactionTime = block.timestamp;
+            _accountInfos[account].lastModifiedMidnightBalanceTime = block.timestamp;
+            _accountInfos[account].midnightBalance = super.balanceOf(account);
+        } else if (intervalDaysOf(_accountInfos[account].lastModifiedMidnightBalanceTime, block.timestamp, 1)) {
+            _accountInfos[account].lastModifiedMidnightBalanceTime = block.timestamp;
+            _accountInfos[account].midnightBalance = super.balanceOf(account);
+            // Reset arigatoCreateionMintToday, but set it to 1 instead of 0 to reduce gas consumption
+            _accountInfos[account].mintArigatoCreationToday = 1;
+        }
+    }
+
+    function _afterTokenTransfer(address from, address to, uint256 amount) internal {
+        emit PCETransfer(from, to, rawBalanceToDisplayBalance(amount), amount);
+    }
+
+    function _mintArigatoCreation(
+        address sender,
+        uint256 rawAmount,
+        uint256 rawBalance,
+        uint256 messageCharacters
+    )
+        internal
+    {
+        // ** Global mint limit
+        uint256 maxArigatoCreationMintToday = midnightTotalSupply * maxIncreaseOfTotalSupplyBp / BP_BASE;
+        console2.log("maxtArigatoCreationToday: %s", maxArigatoCreationMintToday);
+        console2.log("mintArigatoCreationToday: %s", mintArigatoCreationToday);
+        if (maxArigatoCreationMintToday <= 0 || maxArigatoCreationMintToday <= mintArigatoCreationToday) {
+            console2.log("return 167");
+            return;
+        }
+        uint256 remainingArigatoCreationMintToday = maxArigatoCreationMintToday - mintArigatoCreationToday;
+        uint256 remainingArigatoCreationMintTodayForGuest;
+
+        AccountInfo memory accountInfo = _accountInfos[sender];
+
+        bool isGuest = accountInfo.firstTransactionTime == accountInfo.lastModifiedMidnightBalanceTime;
+        if (isGuest) {
+            uint256 maxArigatoCreationMintTodayForGuest = maxArigatoCreationMintToday / 10;
+            if (
+                maxArigatoCreationMintTodayForGuest <= 0
+                    || maxArigatoCreationMintTodayForGuest <= mintArigatoCreationTodayForGuest
+            ) {
+                console2.log("return 182");
+                return;
+            }
+            remainingArigatoCreationMintTodayForGuest =
+                maxArigatoCreationMintTodayForGuest - mintArigatoCreationTodayForGuest;
+        }
+
+        // ** Calculation of mint amount
+        // increaseRate = (maxIncreaseRate - changeRate * abs(maxUsageRate - usageRate)) * valueOfMessageCharacter
+        uint256 usageBp = rawAmount * BP_BASE / rawBalance;
+        uint256 absUsageBp = usageBp > maxUsageBp ? usageBp - maxUsageBp : uint256(maxUsageBp) - usageBp;
+        uint256 changeMulBp = uint256(changeBp) * absUsageBp / BP_BASE;
+        if (changeMulBp >= maxIncreaseBp) {
+            console2.log("changeMulBp >= maxIncreaseBp %s >= %s", changeMulBp, maxIncreaseBp);
+            return;
+        }
+        uint256 messageLength = messageCharacters > 0 ? messageCharacters : 1;
+        uint256 messageBp =
+            messageLength > MAX_CHARACTER_LENGTH ? BP_BASE : messageLength * BP_BASE / MAX_CHARACTER_LENGTH;
+        console2.log("rawAmount: %s, rawBalance: %s", rawAmount, rawBalance);
+        console2.log("usageBp: %s, absUsageBp: %s", usageBp, absUsageBp);
+        console2.log("messageLength: %s, messageBp: %s", messageLength, messageBp);
+        console2.log("maxIncreaseBp: %s, changeBp: %s", maxIncreaseBp, uint256(changeBp));
+        console2.log("changebpmul %s", changeMulBp);
+
+        uint256 increaseBp = uint256(maxIncreaseBp) - changeMulBp * messageBp / BP_BASE;
+        console2.log("increaseBp: %s", increaseBp);
+
+        uint256 mintAmount = rawAmount * increaseBp / BP_BASE;
+        console2.log("mintAmount: %s", mintAmount);
+        if (mintAmount > remainingArigatoCreationMintToday) {
+            console2.log("mintAmount > remainingArigatoCreationMintToday %s", remainingArigatoCreationMintToday);
+            mintAmount = remainingArigatoCreationMintToday;
+        }
+
+        // ** Sender mint limit
+        if (!isGuest) {
+            console2.log("accountInfo.midnightBalance: %s", accountInfo.midnightBalance);
+            console2.log("midnightTotalSupply: %s", midnightTotalSupply);
+            uint256 maxArigatoCreationMintTodayForSender =
+                maxArigatoCreationMintToday * accountInfo.midnightBalance / midnightTotalSupply;
+            if (maxArigatoCreationMintTodayForSender <= 0) {
+                console2.log(
+                    "return maxArigatoCreationMintTodayForSender <= 0 %s", maxArigatoCreationMintTodayForSender
+                );
+                return;
+            }
+            if (mintAmount > maxArigatoCreationMintTodayForSender) {
+                mintAmount = maxArigatoCreationMintTodayForSender;
+            }
+        } else {
+            // Guest can mint only 1% of maxArigatoCreationMintToday
+            if (mintAmount > remainingArigatoCreationMintTodayForGuest) {
+                console2.log(
+                    "mintAmount > remainingArigatoCreationMintTodayForGuest %s",
+                    remainingArigatoCreationMintTodayForGuest
+                );
+                mintAmount = remainingArigatoCreationMintTodayForGuest;
+            }
+            uint256 maxArigatoCreationMintTodayForGuestSender = maxArigatoCreationMintToday / 100;
+            if (maxArigatoCreationMintTodayForGuestSender <= 0) {
+                console2.log(
+                    "return maxArigatoCreationMintTodayForGuestSender <= 0 %s",
+                    maxArigatoCreationMintTodayForGuestSender
+                );
+                return;
+            }
+            if (mintAmount > maxArigatoCreationMintTodayForGuestSender) {
+                console2.log(
+                    "mintAmount > maxArigatoCreationMintTodayForGuestSender %s",
+                    maxArigatoCreationMintTodayForGuestSender
+                );
+                mintAmount = maxArigatoCreationMintTodayForGuestSender;
+            }
+        }
+
+        // ** Execute mint
+        _mint(sender, mintAmount);
+        unchecked {
+            accountInfo.mintArigatoCreationToday += mintAmount;
+            mintArigatoCreationToday += mintAmount;
+            if (isGuest) {
+                mintArigatoCreationTodayForGuest += mintAmount;
+            }
+        }
+        emit MintArigatoCreation(sender, rawBalanceToDisplayBalance(mintAmount), mintAmount);
+        console2.log("complete mintAmount: %s", mintAmount);
+    }
+
+    function transfer(address receiver, uint256 displayAmount) public override returns (bool) {
+        updateFactorIfNeeded();
+        uint256 rawBalance = super.balanceOf(_msgSender());
+        uint256 rawAmount = displayBalanceToRawBalance(displayAmount);
+        // console2.log("rawBalance", rawBalance);
+        // console2.log("rawAmount: %s, displayAmount: %s", rawAmount, displayAmount);
+        bool ret = super.transfer(receiver, rawAmount);
+
+        _mintArigatoCreation(_msgSender(), rawAmount, rawBalance, 1);
+
+        return ret;
+    }
+
+    function transferFrom(address sender, address receiver, uint256 displayBalance) public override returns (bool) {
+        updateFactorIfNeeded();
+        uint256 rawBalance = super.balanceOf(sender);
+        uint256 rawAmount = displayBalanceToRawBalance(displayBalance);
+        bool ret = super.transferFrom(sender, receiver, rawAmount);
+
+        _mintArigatoCreation(sender, rawAmount, rawBalance, 1);
+
+        return ret;
+    }
+
+    function approve(address spender, uint256 displayBalance) public override returns (bool) {
+        updateFactorIfNeeded();
+        uint256 rawBalance = displayBalanceToRawBalance(displayBalance);
+        return super.approve(spender, rawBalance);
+    }
+
+    function allowance(address owner, address spender) public view override returns (uint256) {
+        return rawBalanceToDisplayBalance(super.allowance(owner, spender));
+    }
+
+    function mint(address to, uint256 displayBalance) external {
+        updateFactorIfNeeded();
+        _mint(to, displayBalanceToRawBalance(displayBalance));
+    }
+
+    function burn(uint256 displayBalance) public override {
+        updateFactorIfNeeded();
+        super.burn(displayBalanceToRawBalance(displayBalance));
+    }
+
+    function burnFrom(address account, uint256 displayBalance) public override {
+        updateFactorIfNeeded();
+        super.burnFrom(account, displayBalanceToRawBalance(displayBalance));
+    }
+
+    function intervalDaysOf(uint256 start, uint256 end, uint256 intervalDays) public pure returns (bool) {
+        if (start >= end) {
+            return false;
+        }
+        uint256 startDay = start / 1 days;
+        uint256 endDay = end / 1 days;
+        if (startDay == endDay) {
+            return false;
+        }
+        return (endDay - startDay) >= intervalDays;
+    }
+
+    function _isAllowExchange(bool isIncome, address tokenAddress) private view returns (bool) {
+        ExchangeAllowMethod allowMethod = isIncome ? incomeExchangeAllowMethod : outgoExchangeAllowMethod;
+        address[] memory targetTokens = isIncome ? incomeTargetTokens : outgoTargetTokens;
+        if (allowMethod == ExchangeAllowMethod.None) {
+            return false;
+        } else if (allowMethod == ExchangeAllowMethod.All) {
+            return true;
+        } else if (allowMethod == ExchangeAllowMethod.Include) {
+            for (uint256 i = 0; i < targetTokens.length;) {
+                if (targetTokens[i] == tokenAddress) {
+                    return true;
+                }
+                unchecked {
+                    i++;
+                }
+            }
+            return false;
+        } else if (allowMethod == ExchangeAllowMethod.Exclude) {
+            for (uint256 i = 0; i < targetTokens.length;) {
+                if (targetTokens[i] == tokenAddress) {
+                    return false;
+                }
+                unchecked {
+                    i++;
+                }
+            }
+            return true;
+        } else {
+            revert("Invalid exchangeAllowMethod");
+        }
+    }
+
+    function isAllowOutgoExchange(address tokenAddress) public view returns (bool) {
+        return _isAllowExchange(false, tokenAddress);
+    }
+
+    function isAllowIncomeExchange(address tokenAddress) public view returns (bool) {
+        return _isAllowExchange(true, tokenAddress);
+    }
+
+    /*
+        @dev Swap tokens
+        @param toTokenAddress Address of token to swap
+        @param amountToSwap Amount of token to swap
+    */
+
+    function swapTokens(address toTokenAddress, uint256 amountToSwap) public {
+        address sender = _msgSender();
+        updateFactorIfNeeded();
+        PCEToken pceToken = PCEToken(pceAddress);
+        pceToken.updateFactorIfNeeded();
+
+        Utils.LocalToken memory fromToken = pceToken.getLocalToken(address(this));
+        require(fromToken.isExists, "From token not found");
+
+        Utils.LocalToken memory toToken = pceToken.getLocalToken(toTokenAddress);
+        require(toToken.isExists, "Target token not found");
+
+        PCECommunityTokenV2 to = PCECommunityTokenV2(toTokenAddress);
+        to.updateFactorIfNeeded();
+
+        require(balanceOf(sender) >= amountToSwap, "Insufficient balance");
+        require(isAllowOutgoExchange(toTokenAddress), "Outgo exchange not allowed");
+        require(to.isAllowIncomeExchange(address(this)), "Income exchange not allowed");
+
+        uint256 targetTokenAmount =
+            amountToSwap * 10 ** 18 / fromToken.exchangeRate * pceToken.getCurrentFactor() / getCurrentFactor();
+        targetTokenAmount = targetTokenAmount * toToken.exchangeRate / INITIAL_FACTOR * to.getCurrentFactor()
+            / pceToken.getCurrentFactor();
+        require(targetTokenAmount > 0, "Invalid amount to swap");
+
+        super._burn(sender, displayBalanceToRawBalance(amountToSwap));
+        to.mint(sender, targetTokenAmount);
+    }
+
+    /*
+        @notice Returns the fee in this token for the meta transaction in the current block.
+    */
+    function getMetaTransactionFee() public view returns (uint256) {
+        PCEToken pceToken = PCEToken(pceAddress);
+        uint256 pceTokenFee = pceToken.getMetaTransactionFee();
+        uint256 rate = pceToken.getSwapRate(address(this));
+        return pceTokenFee * rate >> 96;
+    }
+
+    function transferWithAuthorization(
+        address from,
+        address to,
+        uint256 displayAmount,
+        uint256 validAfter,
+        uint256 validBefore,
+        bytes32 nonce,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    )
+        public
+        override
+    {
+        updateFactorIfNeeded();
+        uint256 rawBalance = super.balanceOf(from);
+        uint256 rawAmount = displayBalanceToRawBalance(displayAmount);
+        uint256 displayFee = getMetaTransactionFee();
+        uint256 rawFee = displayBalanceToRawBalance(displayFee);
+        _transferWithAuthorization(from, to, displayAmount, validAfter, validBefore, nonce, v, r, s, rawAmount);
+
+        super._transfer(from, _msgSender(), rawFee);
+
+        emit MetaTransactionFeeCollected(from, _msgSender(), displayFee, rawFee);
+
+        _mintArigatoCreation(from, rawAmount, rawBalance, 1);
+    }
+
+    /*
+        @notice Returns the total balance that can be swapped to PCE today
+        The balance is 0.01 times the total supply at UTC 0
+    */
+    function getTodaySwapableToPCEBalance() public view returns (uint256) {
+        PCEToken pceToken = PCEToken(pceAddress);
+
+        return rawBalanceToDisplayBalance(midnightTotalSupply * pceToken.swapableToPCERate() / BP_BASE);
+    }
+
+    /*
+        @notice Returns the total balance that can be swapped to PCE today for the individual
+        The balance is 0.01 times the balance of the individual at UTC 0
+    */
+    function getTodaySwapableToPCEBalanceForIndividual(address checkAddress) public view returns (uint256) {
+        PCEToken pceToken = PCEToken(pceAddress);
+
+        AccountInfo memory accountInfo = _accountInfos[checkAddress];
+
+        return
+            rawBalanceToDisplayBalance(accountInfo.midnightBalance * pceToken.swapableToPCEIndividualRate() / BP_BASE);
+    }
+
+    function version() public pure returns (string memory) {
+        return "1.0.1";
+    }
+}

--- a/src/PCEToken.sol
+++ b/src/PCEToken.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.26;
 
+import { BeaconProxy } from "@openzeppelin/contracts/proxy/beacon/BeaconProxy.sol";
 import { UUPSUpgradeable } from "@openzeppelin/contracts/proxy/utils/UUPSUpgradeable.sol";
 import { ERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol";
 import { OwnableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
@@ -168,9 +169,12 @@ contract PCEToken is
 
         updateFactorIfNeeded();
 
-        address newTokenAddress = Clones.clone(_communityTokenAddress);
+        BeaconProxy proxy = new BeaconProxy(
+            _communityTokenAddress,
+            abi.encodeWithSelector(PCECommunityToken(address(0)).initialize.selector, name, symbol, lastModifiedFactor)
+        );
+        address newTokenAddress = address(proxy);
         PCECommunityToken newToken = PCECommunityToken(newTokenAddress);
-        newToken.initialize(name, symbol, lastModifiedFactor);
         newToken.setTokenSettings(
             decreaseIntervalDays,
             afterDecreaseBp,

--- a/src/PCETokenV2.sol
+++ b/src/PCETokenV2.sol
@@ -13,7 +13,9 @@ import { Utils } from "./lib/Utils.sol";
 import { ExchangeAllowMethod } from "./lib/Enum.sol";
 import { NativeMetaTransaction } from "./lib/polygon/NativeMetaTransaction.sol";
 
-contract PCEToken is
+/// @custom:oz-upgrades-from PCEToken
+
+contract PCETokenV2 is
     UUPSUpgradeable,
     Initializable,
     ERC20Upgradeable,
@@ -55,31 +57,7 @@ contract PCEToken is
     uint256 public lastDecreaseTime;
     uint256 public lastModifiedFactor;
 
-    function initialize(
-        string memory _name,
-        string memory _symbol,
-        address communityTokenAddress,
-        address _polygonChainManager
-    )
-        public
-        initializer
-    {
-        __ERC20_init(_name, _symbol);
-        __Ownable_init(_msgSender());
-        _mint(_msgSender(), 10_000 * INITIAL_FACTOR);
-        // initial rate is 1(NativeToken):5(PCEToken) = 5<<96 = 396140812571321687967719751680
-        nativeTokenToPceTokenRate = 396_140_812_571_321_687_967_719_751_680;
-        metaTransactionGas = 200_000;
-        metaTransactionPriorityFee = 50_000_000_000; // 50 gwei
-        swapableToPCERate = 300; // 300BP is 3%
-        swapableToPCEIndividualRate = 300; // 300BP is 3%
-
-        _communityTokenAddress = communityTokenAddress;
-        epochTime = block.timestamp;
-        lastDecreaseTime = block.timestamp;
-        lastModifiedFactor = INITIAL_FACTOR;
-        polygonChainManager = _polygonChainManager;
-    }
+    function initialize() public initializer { }
 
     function getLocalToken(address communityToken) public view returns (Utils.LocalToken memory) {
         return localTokens[communityToken];
@@ -351,6 +329,6 @@ contract PCEToken is
     function _authorizeUpgrade(address newImplementation) internal virtual override onlyOwner { }
 
     function version() public pure returns (string memory) {
-        return "1.0.0";
+        return "1.0.1";
     }
 }

--- a/src/PCETokenV2.sol
+++ b/src/PCETokenV2.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.26;
 
+import { BeaconProxy } from "@openzeppelin/contracts/proxy/beacon/BeaconProxy.sol";
 import { UUPSUpgradeable } from "@openzeppelin/contracts/proxy/utils/UUPSUpgradeable.sol";
 import { ERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol";
 import { OwnableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
@@ -146,9 +147,12 @@ contract PCETokenV2 is
 
         updateFactorIfNeeded();
 
-        address newTokenAddress = Clones.clone(_communityTokenAddress);
+        BeaconProxy proxy = new BeaconProxy(
+            _communityTokenAddress,
+            abi.encodeWithSelector(PCECommunityToken(address(0)).initialize.selector, name, symbol, lastModifiedFactor)
+        );
+        address newTokenAddress = address(proxy);
         PCECommunityToken newToken = PCECommunityToken(newTokenAddress);
-        newToken.initialize(name, symbol, lastModifiedFactor);
         newToken.setTokenSettings(
             decreaseIntervalDays,
             afterDecreaseBp,

--- a/src/lib/TokenSetting.sol
+++ b/src/lib/TokenSetting.sol
@@ -5,9 +5,9 @@ import { OwnableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/O
 import { ExchangeAllowMethod } from "./Enum.sol";
 
 contract TokenSetting is OwnableUpgradeable {
-    uint256 public decreaseIntervalDays = 0;
-    uint256 public lastDecreaseTime = 0;
-    uint16 public afterDecreaseBp = 0;
+    uint256 public decreaseIntervalDays;
+    uint256 public lastDecreaseTime;
+    uint16 public afterDecreaseBp;
     // Bp is 1/10000
     uint16 public maxIncreaseOfTotalSupplyBp;
     uint16 public maxIncreaseBp;
@@ -19,8 +19,8 @@ contract TokenSetting is OwnableUpgradeable {
     uint256 public mintArigatoCreationToday;
     uint256 public mintArigatoCreationTodayForGuest;
 
-    ExchangeAllowMethod public incomeExchangeAllowMethod = ExchangeAllowMethod.None;
-    ExchangeAllowMethod public outgoExchangeAllowMethod = ExchangeAllowMethod.None;
+    ExchangeAllowMethod public incomeExchangeAllowMethod;
+    ExchangeAllowMethod public outgoExchangeAllowMethod;
 
     address[] public incomeTargetTokens;
     address[] public outgoTargetTokens;

--- a/src/lib/polygon/PolygonInitializable.sol
+++ b/src/lib/polygon/PolygonInitializable.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.26;
 
 contract PolygonInitializable {
-    bool inited = false;
+    bool inited;
 
     modifier polygonInitializer() {
         require(!inited, "already inited");


### PR DESCRIPTION
Unified the implementation of PCECommunityToken using BeaconProxy, allowing for upgrades. Now, all community token implementations can be upgraded in a single transaction.

refs.
- https://docs.openzeppelin.com/contracts/5.x/api/proxy