### PR TITLE
feat: get raw allowance on approve

### DIFF
--- a/src/PCECommunityToken.sol
+++ b/src/PCECommunityToken.sol
@@ -279,6 +279,22 @@ contract PCECommunityToken is
         return ret;
     }
 
+    function _spendAllowance(address owner, address spender, uint256 value) internal virtual override {
+        // PCECommunityToken's change
+        // get raw allowance
+        // - uint256 currentAllowance = allowance(owner, spender);
+        // + uint256 currentAllowance = super.allowance(owner, spender);
+        uint256 currentAllowance = super.allowance(owner, spender);
+        if (currentAllowance != type(uint256).max) {
+            if (currentAllowance < value) {
+                revert ERC20InsufficientAllowance(spender, currentAllowance, value);
+            }
+            unchecked {
+                _approve(owner, spender, currentAllowance - value, false);
+            }
+        }
+    }
+
     function transferFrom(address sender, address receiver, uint256 displayBalance) public override returns (bool) {
         updateFactorIfNeeded();
         uint256 rawBalance = super.balanceOf(sender);

--- a/src/PCECommunityTokenV2.sol
+++ b/src/PCECommunityTokenV2.sol
@@ -273,6 +273,22 @@ contract PCECommunityTokenV2 is
         return ret;
     }
 
+    function _spendAllowance(address owner, address spender, uint256 value) internal virtual override {
+        // PCECommunityToken's change
+        // get raw allowance
+        // - uint256 currentAllowance = allowance(owner, spender);
+        // + uint256 currentAllowance = super.allowance(owner, spender);
+        uint256 currentAllowance = super.allowance(owner, spender);
+        if (currentAllowance != type(uint256).max) {
+            if (currentAllowance < value) {
+                revert ERC20InsufficientAllowance(spender, currentAllowance, value);
+            }
+            unchecked {
+                _approve(owner, spender, currentAllowance - value, false);
+            }
+        }
+    }
+
     function transferFrom(address sender, address receiver, uint256 displayBalance) public override returns (bool) {
         updateFactorIfNeeded();
         uint256 rawBalance = super.balanceOf(sender);


### PR DESCRIPTION
During the development of [erc20-voucher](https://github.com/peacecoin-protocol/erc20-voucher), we noticed that the part of the approve function that gets the amount of allowance used inside the approve function by inheriting `ERC20Upgradeable` was using the `display balance`, which could fail even if the amount was more than the actual allowance `raw balance`, it would fail even if the amount was more than the actual allowance.
Fixed to override `_spendAllowance` in `ERC20Upgradeable` to use the correct raw balance.
