### PR TITLE
feat: v10, fix swapFromLocalToken and weekly depreciation

### DIFF
--- a/script/Upgrade.s.sol
+++ b/script/Upgrade.s.sol
@@ -11,7 +11,7 @@ contract Upgrade is BaseScript {
         address pceTokenAddress = 0xA4807a8C34353A5EA51aF073175950Cb6248dA7E;
         address pceCommunityTokenAddress = 0x6A73A610707C113F34D8B82498b6868e5f7FAA74;
 
-        Upgrades.upgradeProxy(pceTokenAddress, "PCETokenV8.sol:PCETokenV8", "");
-        Upgrades.upgradeBeacon(pceCommunityTokenAddress, "PCECommunityTokenV8.sol:PCECommunityTokenV8");
+        Upgrades.upgradeProxy(pceTokenAddress, "PCETokenV10.sol:PCETokenV10", "");
+        Upgrades.upgradeBeacon(pceCommunityTokenAddress, "PCECommunityTokenV10.sol:PCECommunityTokenV10");
     }
 }

--- a/script/UpgradeDEV.s.sol
+++ b/script/UpgradeDEV.s.sol
@@ -11,7 +11,7 @@ contract UpgradeDEV is BaseScript {
         address pceTokenAddress = 0x62Ef93EAa5bB3E47E0e855C323ef156c8E3D8913;
         address pceCommunityTokenAddress = 0xA9D965660dcF0fA73E709fd802e9DEF2d9b52952;
 
-        Upgrades.upgradeProxy(pceTokenAddress, "PCETokenV9.sol:PCETokenV9", "");
-        Upgrades.upgradeBeacon(pceCommunityTokenAddress, "PCECommunityTokenV9.sol:PCECommunityTokenV9");
+        Upgrades.upgradeProxy(pceTokenAddress, "PCETokenV10.sol:PCETokenV10", "");
+        Upgrades.upgradeBeacon(pceCommunityTokenAddress, "PCECommunityTokenV10.sol:PCECommunityTokenV10");
     }
 }

--- a/script/deploy-dev.sh
+++ b/script/deploy-dev.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$ROOT_DIR"
+
+echo "=== Stripping console2 from src/ for deployment ==="
+
+FILES=$(grep -rl 'console2' src/ || true)
+
+if [ -z "$FILES" ]; then
+    echo "No console2 usage found in src/"
+else
+    for f in $FILES; do
+        echo "  Stripping: $f"
+        perl -0777 -i -pe '
+            s/^\s*import\s*\{?\s*console2\s*\}?\s*from\s*"[^"]*";\s*\n//gm;
+            s/^\s*console2\.log\([^;]*\);\s*\n//gm;
+            s/^\s*\/\/.*console2.*\n//gm;
+        ' "$f"
+    done
+fi
+
+echo "=== Building ==="
+forge clean && forge build
+
+echo "=== Deploying UpgradeDEV ==="
+source .env
+forge script script/UpgradeDEV.s.sol --broadcast --fork-url polygon --interactives 1 --code-size-limit 49152
+
+echo "=== Restoring original source files ==="
+git checkout src/
+
+echo "=== Done ==="

--- a/script/deploy.sh
+++ b/script/deploy.sh
@@ -5,12 +5,26 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 cd "$ROOT_DIR"
 
+# Determine target: dev or prd
+TARGET="${1:-dev}"
+
+if [ "$TARGET" = "dev" ]; then
+    FORGE_SCRIPT="script/UpgradeDEV.s.sol"
+    echo "=== Deploying to DEV (Polygon mainnet) ==="
+elif [ "$TARGET" = "prd" ]; then
+    FORGE_SCRIPT="script/Upgrade.s.sol"
+    echo "=== Deploying to PRD (Polygon mainnet) ==="
+else
+    echo "Usage: $0 [dev|prd]"
+    exit 1
+fi
+
 echo "=== Stripping console2 from src/ for deployment ==="
 
 FILES=$(grep -rl 'console2' src/ || true)
 
 if [ -z "$FILES" ]; then
-    echo "No console2 usage found in src/"
+    echo "  No console2 usage found in src/"
 else
     for f in $FILES; do
         echo "  Stripping: $f"
@@ -25,9 +39,16 @@ fi
 echo "=== Building ==="
 forge clean && forge build
 
-echo "=== Deploying UpgradeDEV ==="
 source .env
-forge script script/UpgradeDEV.s.sol --broadcast --fork-url polygon --interactives 1 --code-size-limit 49152
+
+echo "=== Deploying $FORGE_SCRIPT ==="
+forge script "$FORGE_SCRIPT" \
+    --broadcast \
+    --fork-url polygon \
+    --interactives 1 \
+    --code-size-limit 49152 \
+    --verify \
+    --etherscan-api-key "$API_KEY_POLYGONSCAN"
 
 echo "=== Restoring original source files ==="
 git checkout src/

--- a/src/PCECommunityTokenV10.sol
+++ b/src/PCECommunityTokenV10.sol
@@ -18,7 +18,7 @@ import { VoucherSystem } from "./lib/VoucherSystem.sol";
 
 import { console2 } from "forge-std/console2.sol";
 
-/// @custom:oz-upgrades-from PCECommunityTokenV8
+/// @custom:oz-upgrades-from PCECommunityTokenV9
 
 contract PCECommunityTokenV10 is
     Initializable,
@@ -379,6 +379,7 @@ contract PCECommunityTokenV10 is
     }
 
     function mint(address to, uint256 displayBalance) external {
+        require(_msgSender() == owner() || _msgSender() == pceAddress, "Only owner or PCE token");
         updateFactorIfNeeded();
         _mint(to, displayBalanceToRawBalance(displayBalance));
     }

--- a/src/PCECommunityTokenV10.sol
+++ b/src/PCECommunityTokenV10.sol
@@ -1,0 +1,876 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import { ERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol";
+import { ERC20BurnableUpgradeable } from
+    "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC20BurnableUpgradeable.sol";
+import { Initializable } from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import { OwnableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import { ERC20PermitUpgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC20PermitUpgradeable.sol";
+import { PCETokenV10 } from "./PCETokenV10.sol";
+import { Utils } from "./lib/Utils.sol";
+import { EIP3009 } from "./lib/EIP3009.sol";
+import { EIP712 } from "./lib/EIP712.sol";
+import { TokenSetting } from "./lib/TokenSetting.sol";
+import { ExchangeAllowMethod } from "./lib/Enum.sol";
+import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
+import { VoucherSystem } from "./lib/VoucherSystem.sol";
+
+import { console2 } from "forge-std/console2.sol";
+
+/// @custom:oz-upgrades-from PCECommunityTokenV8
+
+contract PCECommunityTokenV10 is
+    Initializable,
+    ERC20Upgradeable,
+    ERC20BurnableUpgradeable,
+    OwnableUpgradeable,
+    EIP3009,
+    ERC20PermitUpgradeable,
+    TokenSetting
+{
+    uint256 public constant INITIAL_FACTOR = 10 ** 18;
+    uint16 public constant BP_BASE = 10_000;
+    uint16 public constant MAX_CHARACTER_LENGTH = 10;
+
+    /*
+        keccak256(
+            "TransferFromWithAuthorization(address spender,address from,address to,
+                uint256 value,uint256 validAfter,uint256 validBefore,bytes32 nonce)"
+        )
+    */
+    bytes32 public constant TRANSFER_FROM_WITH_AUTHORIZATION_TYPEHASH =
+        0xdc2e81fe1efc0fd8f409b4ea3e0551766bc1a7f569028058d8b21a404fd81480;
+
+    /*
+        keccak256(
+            "SetInfinityApproveFlagWithAuthorization(address owner,address spender,
+                bool flag,uint256 validAfter,uint256 validBefore,bytes32 nonce)"
+        )
+    */
+    bytes32 public constant SET_INFINITY_APPROVE_FLAG_WITH_AUTHORIZATION_TYPEHASH =
+        0xae8989bee557ad51c17ff078fc59b7a54343dae31bac9bad6f6c9fe90486684e;
+
+    /*
+        keccak256(
+            "ClaimWithAuthorization(address claimer,string issuanceId,string code,
+                uint256 validAfter,uint256 validBefore,bytes32 nonce)"
+        )
+    */
+    bytes32 public constant CLAIM_WITH_AUTHORIZATION_TYPEHASH =
+        0x0b6aae1d90e3a85a25061f4c51e754a9cce2a86cf2f51fb09be1001de8fb7c0a;
+
+    address public pceAddress;
+    uint256 public initialFactor;
+    uint256 public epochTime;
+    uint256 public lastModifiedFactor;
+
+    struct AccountInfo {
+        uint256 midnightBalance;
+        uint256 firstTransactionTime;
+        uint256 lastModifiedMidnightBalanceTime;
+        uint256 mintArigatoCreationToday;
+    }
+
+    struct VoucherIssuanceInfo {
+        string issuanceId;
+        address owner;
+        string name;
+        uint256 amountPerClaim;
+        uint256 countLimitPerUser;
+        uint256 totalAmountLimit;
+        uint256 startTime;
+        uint256 endTime;
+        bytes32 merkleRoot;
+        bool isActive;
+        uint256 remainingAmount;
+        uint256 claimedAmount;
+        uint256 claimedDisplayAmount;
+        uint256 totalClaimCount;
+        string ipfsCid;  // Optional IPFS CID for additional metadata
+    }
+
+    mapping(address user => AccountInfo accountInfo) private _accountInfos;
+    mapping(address owner => mapping(address spender => bool flag)) private _infinityApproveFlags;
+
+    VoucherSystem.VoucherStorage private _voucherStorage;
+
+    event PCETransfer(address indexed from, address indexed to, uint256 displayAmount, uint256 rawAmount);
+    event MintArigatoCreation(address indexed to, uint256 displayAmount, uint256 rawAmount);
+    event MetaTransactionFeeCollected(address indexed from, address indexed to, uint256 displayFee, uint256 rawFee);
+    event InfinityApproveFlagSet(address indexed owner, address indexed spender, bool flag);
+
+    function initialize(string memory name, string memory symbol, uint256 _initialFactor) public initializer {
+        __ERC20_init(name, symbol);
+        __Ownable_init(_msgSender());
+        __ERC20Permit_init(name);
+        pceAddress = _msgSender();
+        epochTime = block.timestamp;
+        lastDecreaseTime = block.timestamp;
+        initialFactor = _initialFactor;
+        lastModifiedFactor = _initialFactor;
+    }
+
+    function getCurrentFactor() public view returns (uint256) {
+        if (lastModifiedFactor == 0) {
+            return 0;
+        }
+        if (decreaseIntervalDays == 0) {
+            return lastModifiedFactor;
+        }
+        if (intervalDaysOf(lastDecreaseTime, block.timestamp, decreaseIntervalDays)) {
+            return Math.mulDiv(lastModifiedFactor, afterDecreaseBp, BP_BASE);
+        } else {
+            return lastModifiedFactor;
+        }
+    }
+
+    function updateFactorIfNeeded() public {
+        if (lastDecreaseTime == block.timestamp) {
+            return;
+        }
+
+        PCETokenV10 pceToken = PCETokenV10(pceAddress);
+        pceToken.updateFactorIfNeeded();
+
+        uint256 currentFactor = getCurrentFactor();
+        if (currentFactor != lastModifiedFactor) {
+            lastModifiedFactor = currentFactor;
+            lastDecreaseTime = block.timestamp;
+        }
+    }
+
+    function rawBalanceToDisplayBalance(uint256 rawBalance) public view returns (uint256) {
+        uint256 currentFactor = getCurrentFactor();
+        if (currentFactor < 1) {
+            currentFactor = 1;
+        }
+        return rawBalance / currentFactor;
+    }
+
+    function displayBalanceToRawBalance(uint256 displayBalance) public view returns (uint256) {
+        uint256 currentFactor = getCurrentFactor();
+        if (currentFactor < 1) {
+            currentFactor = 1;
+        }
+        return displayBalance * currentFactor;
+    }
+
+    function totalSupply() public view override returns (uint256) {
+        return rawBalanceToDisplayBalance(super.totalSupply());
+    }
+
+    function balanceOf(address account) public view override returns (uint256) {
+        return rawBalanceToDisplayBalance(super.balanceOf(account));
+    }
+
+    function _update(address from, address to, uint256 value) internal override {
+        _beforeTokenTransfer(from, to, value);
+        super._update(from, to, value);
+        _afterTokenTransfer(from, to, value);
+    }
+
+    function _beforeTokenTransfer(address from, address to, uint256 amount) internal {
+        if (midnightTotalSupplyModifiedTime == 0) {
+            midnightTotalSupply = amount;
+            midnightTotalSupplyModifiedTime = block.timestamp;
+        } else if (intervalDaysOf(midnightTotalSupplyModifiedTime, block.timestamp, 1)) {
+            midnightTotalSupply = super.totalSupply();
+            midnightTotalSupplyModifiedTime = block.timestamp;
+            // Reset arigatoCreateionMintToday, but set it to 1 instead of 0 to reduce gas consumption
+            mintArigatoCreationToday = 1;
+            mintArigatoCreationTodayForGuest = 1;
+        }
+        if (from != address(0)) {
+            _beforeTokenTransferAtAddress(from);
+        }
+        if (to != address(0)) {
+            _beforeTokenTransferAtAddress(to);
+        }
+    }
+
+    function _beforeTokenTransferAtAddress(address account) internal {
+        if (_accountInfos[account].firstTransactionTime == 0) {
+            _accountInfos[account].firstTransactionTime = block.timestamp;
+            _accountInfos[account].lastModifiedMidnightBalanceTime = block.timestamp;
+            _accountInfos[account].midnightBalance = super.balanceOf(account);
+        } else if (intervalDaysOf(_accountInfos[account].lastModifiedMidnightBalanceTime, block.timestamp, 1)) {
+            _accountInfos[account].lastModifiedMidnightBalanceTime = block.timestamp;
+            _accountInfos[account].midnightBalance = super.balanceOf(account);
+            // Reset arigatoCreateionMintToday, but set it to 1 instead of 0 to reduce gas consumption
+            _accountInfos[account].mintArigatoCreationToday = 1;
+        }
+    }
+
+    function _afterTokenTransfer(address from, address to, uint256 amount) internal {
+        emit PCETransfer(from, to, rawBalanceToDisplayBalance(amount), amount);
+    }
+
+    function _mintArigatoCreation(
+        address sender,
+        uint256 rawAmount,
+        uint256 rawBalance,
+        uint256 messageCharacters
+    )
+        internal
+    {
+        // ** Global mint limit
+        uint256 maxArigatoCreationMintToday = Math.mulDiv(midnightTotalSupply, maxIncreaseOfTotalSupplyBp, BP_BASE);
+        console2.log("maxtArigatoCreationToday: %s", maxArigatoCreationMintToday);
+        console2.log("mintArigatoCreationToday: %s", mintArigatoCreationToday);
+        if (maxArigatoCreationMintToday <= 0 || maxArigatoCreationMintToday <= mintArigatoCreationToday) {
+            console2.log("return 167");
+            return;
+        }
+        uint256 remainingArigatoCreationMintToday = maxArigatoCreationMintToday - mintArigatoCreationToday;
+        uint256 remainingArigatoCreationMintTodayForGuest;
+
+        AccountInfo memory accountInfo = _accountInfos[sender];
+
+        bool isGuest = accountInfo.firstTransactionTime == accountInfo.lastModifiedMidnightBalanceTime;
+        if (isGuest) {
+            uint256 maxArigatoCreationMintTodayForGuest = Math.mulDiv(maxArigatoCreationMintToday, 1, 10);
+            if (
+                maxArigatoCreationMintTodayForGuest <= 0
+                    || maxArigatoCreationMintTodayForGuest <= mintArigatoCreationTodayForGuest
+            ) {
+                console2.log("return 182");
+                return;
+            }
+            remainingArigatoCreationMintTodayForGuest =
+                maxArigatoCreationMintTodayForGuest - mintArigatoCreationTodayForGuest;
+        }
+
+        // ** Calculation of mint amount
+        // increaseRate = (maxIncreaseRate - changeRate * abs(maxUsageRate - usageRate)) * valueOfMessageCharacter
+        uint256 usageBp = Math.mulDiv(rawAmount, BP_BASE, rawBalance);
+        uint256 absUsageBp = usageBp > maxUsageBp ? usageBp - maxUsageBp : uint256(maxUsageBp) - usageBp;
+        uint256 changeMulBp = Math.mulDiv(uint256(changeBp), absUsageBp, BP_BASE);
+        if (changeMulBp >= maxIncreaseBp) {
+            console2.log("changeMulBp >= maxIncreaseBp %s >= %s", changeMulBp, maxIncreaseBp);
+            return;
+        }
+        uint256 messageLength = messageCharacters > 0 ? messageCharacters : 1;
+        uint256 messageBp =
+            messageLength > MAX_CHARACTER_LENGTH ? BP_BASE : Math.mulDiv(messageLength, BP_BASE, MAX_CHARACTER_LENGTH);
+        console2.log("rawAmount: %s, rawBalance: %s", rawAmount, rawBalance);
+        console2.log("usageBp: %s, absUsageBp: %s", usageBp, absUsageBp);
+        console2.log("messageLength: %s, messageBp: %s", messageLength, messageBp);
+        console2.log("maxIncreaseBp: %s, changeBp: %s", maxIncreaseBp, uint256(changeBp));
+        console2.log("changebpmul %s", changeMulBp);
+
+        uint256 increaseBp = uint256(maxIncreaseBp) - Math.mulDiv(changeMulBp, messageBp, BP_BASE);
+        console2.log("increaseBp: %s", increaseBp);
+
+        uint256 mintAmount = Math.mulDiv(rawAmount, increaseBp, BP_BASE);
+        console2.log("mintAmount: %s", mintAmount);
+        if (mintAmount > remainingArigatoCreationMintToday) {
+            console2.log("mintAmount > remainingArigatoCreationMintToday %s", remainingArigatoCreationMintToday);
+            mintAmount = remainingArigatoCreationMintToday;
+        }
+
+        // ** Sender mint limit
+        if (!isGuest) {
+            console2.log("accountInfo.midnightBalance: %s", accountInfo.midnightBalance);
+            console2.log("midnightTotalSupply: %s", midnightTotalSupply);
+            uint256 maxArigatoCreationMintTodayForSender =
+                Math.mulDiv(maxArigatoCreationMintToday, accountInfo.midnightBalance, midnightTotalSupply);
+            if (maxArigatoCreationMintTodayForSender <= 0) {
+                console2.log(
+                    "return maxArigatoCreationMintTodayForSender <= 0 %s", maxArigatoCreationMintTodayForSender
+                );
+                return;
+            }
+            if (mintAmount > maxArigatoCreationMintTodayForSender) {
+                mintAmount = maxArigatoCreationMintTodayForSender;
+            }
+        } else {
+            // Guest can mint only 1% of maxArigatoCreationMintToday
+            if (mintAmount > remainingArigatoCreationMintTodayForGuest) {
+                console2.log(
+                    "mintAmount > remainingArigatoCreationMintTodayForGuest %s",
+                    remainingArigatoCreationMintTodayForGuest
+                );
+                mintAmount = remainingArigatoCreationMintTodayForGuest;
+            }
+            uint256 maxArigatoCreationMintTodayForGuestSender = Math.mulDiv(maxArigatoCreationMintToday, 1, 100);
+            if (maxArigatoCreationMintTodayForGuestSender <= 0) {
+                console2.log(
+                    "return maxArigatoCreationMintTodayForGuestSender <= 0 %s",
+                    maxArigatoCreationMintTodayForGuestSender
+                );
+                return;
+            }
+            if (mintAmount > maxArigatoCreationMintTodayForGuestSender) {
+                console2.log(
+                    "mintAmount > maxArigatoCreationMintTodayForGuestSender %s",
+                    maxArigatoCreationMintTodayForGuestSender
+                );
+                mintAmount = maxArigatoCreationMintTodayForGuestSender;
+            }
+        }
+
+        // ** Execute mint
+        _mint(sender, mintAmount);
+        unchecked {
+            accountInfo.mintArigatoCreationToday += mintAmount;
+            mintArigatoCreationToday += mintAmount;
+            if (isGuest) {
+                mintArigatoCreationTodayForGuest += mintAmount;
+            }
+        }
+        emit MintArigatoCreation(sender, rawBalanceToDisplayBalance(mintAmount), mintAmount);
+        console2.log("complete mintAmount: %s", mintAmount);
+    }
+
+    function transfer(address receiver, uint256 displayAmount) public override returns (bool) {
+        updateFactorIfNeeded();
+        uint256 rawBalance = super.balanceOf(_msgSender());
+        uint256 rawAmount = displayBalanceToRawBalance(displayAmount);
+        // console2.log("rawBalance", rawBalance);
+        // console2.log("rawAmount: %s, displayAmount: %s", rawAmount, displayAmount);
+        bool ret = super.transfer(receiver, rawAmount);
+
+        _mintArigatoCreation(_msgSender(), rawAmount, rawBalance, 1);
+
+        return ret;
+    }
+
+    function _spendAllowance(address owner, address spender, uint256 value) internal virtual override {
+        // Check infinity approve flag first
+        if (_infinityApproveFlags[owner][spender]) {
+            return; // Skip allowance check if infinity approve flag is set
+        }
+
+        // PCECommunityToken's change
+        // get raw allowance
+        // - uint256 currentAllowance = allowance(owner, spender);
+        // + uint256 currentAllowance = super.allowance(owner, spender);
+        uint256 currentAllowance = super.allowance(owner, spender);
+        if (currentAllowance != type(uint256).max) {
+            if (currentAllowance < value) {
+                revert ERC20InsufficientAllowance(spender, currentAllowance, value);
+            }
+            unchecked {
+                _approve(owner, spender, currentAllowance - value, false);
+            }
+        }
+    }
+
+    function transferFrom(address sender, address receiver, uint256 displayBalance) public override returns (bool) {
+        updateFactorIfNeeded();
+        uint256 rawBalance = super.balanceOf(sender);
+        uint256 rawAmount = displayBalanceToRawBalance(displayBalance);
+        bool ret = super.transferFrom(sender, receiver, rawAmount);
+
+        _mintArigatoCreation(sender, rawAmount, rawBalance, 1);
+
+        return ret;
+    }
+
+    function approve(address spender, uint256 displayBalance) public override returns (bool) {
+        updateFactorIfNeeded();
+        uint256 rawBalance = displayBalanceToRawBalance(displayBalance);
+        return super.approve(spender, rawBalance);
+    }
+
+    function allowance(address owner, address spender) public view override returns (uint256) {
+        return rawBalanceToDisplayBalance(super.allowance(owner, spender));
+    }
+
+    function mint(address to, uint256 displayBalance) external {
+        updateFactorIfNeeded();
+        _mint(to, displayBalanceToRawBalance(displayBalance));
+    }
+
+    function burn(uint256 displayBalance) public override {
+        updateFactorIfNeeded();
+        super.burn(displayBalanceToRawBalance(displayBalance));
+    }
+
+    function burnFrom(address account, uint256 displayBalance) public override {
+        updateFactorIfNeeded();
+        super.burnFrom(account, displayBalanceToRawBalance(displayBalance));
+    }
+
+    function burnByPCEToken(address account, uint256 displayBalance) external {
+        require(_msgSender() == pceAddress, "Only PCE token");
+        updateFactorIfNeeded();
+        _burn(account, displayBalanceToRawBalance(displayBalance));
+    }
+
+    function intervalDaysOf(uint256 start, uint256 end, uint256 intervalDays) public pure returns (bool) {
+        if (start >= end) {
+            return false;
+        }
+        uint256 startDay = start / 1 days;
+        uint256 endDay = end / 1 days;
+        if (startDay == endDay) {
+            return false;
+        }
+        return (endDay - startDay) >= intervalDays;
+    }
+
+    function _isAllowExchange(bool isIncome, address tokenAddress) private view returns (bool) {
+        ExchangeAllowMethod allowMethod = isIncome ? incomeExchangeAllowMethod : outgoExchangeAllowMethod;
+        address[] memory targetTokens = isIncome ? incomeTargetTokens : outgoTargetTokens;
+        if (allowMethod == ExchangeAllowMethod.None) {
+            return false;
+        } else if (allowMethod == ExchangeAllowMethod.All) {
+            return true;
+        } else if (allowMethod == ExchangeAllowMethod.Include) {
+            for (uint256 i = 0; i < targetTokens.length;) {
+                if (targetTokens[i] == tokenAddress) {
+                    return true;
+                }
+                unchecked {
+                    i++;
+                }
+            }
+            return false;
+        } else if (allowMethod == ExchangeAllowMethod.Exclude) {
+            for (uint256 i = 0; i < targetTokens.length;) {
+                if (targetTokens[i] == tokenAddress) {
+                    return false;
+                }
+                unchecked {
+                    i++;
+                }
+            }
+            return true;
+        } else {
+            revert("Invalid exchangeAllowMethod");
+        }
+    }
+
+    function isAllowOutgoExchange(address tokenAddress) public view returns (bool) {
+        return _isAllowExchange(false, tokenAddress);
+    }
+
+    function isAllowIncomeExchange(address tokenAddress) public view returns (bool) {
+        return _isAllowExchange(true, tokenAddress);
+    }
+
+    /*
+        @dev Swap tokens
+        @param toTokenAddress Address of token to swap
+        @param amountToSwap Amount of token to swap
+    */
+
+    function swapTokens(address toTokenAddress, uint256 amountToSwap) public {
+        address sender = _msgSender();
+        updateFactorIfNeeded();
+        PCETokenV10 pceToken = PCETokenV10(pceAddress);
+        pceToken.updateFactorIfNeeded();
+
+        Utils.LocalToken memory fromToken = pceToken.getLocalToken(address(this));
+        require(fromToken.isExists, "From token not found");
+
+        Utils.LocalToken memory toToken = pceToken.getLocalToken(toTokenAddress);
+        require(toToken.isExists, "Target token not found");
+
+        PCECommunityTokenV10 to = PCECommunityTokenV10(toTokenAddress);
+        to.updateFactorIfNeeded();
+
+        require(balanceOf(sender) >= amountToSwap, "Insufficient balance");
+        require(isAllowOutgoExchange(toTokenAddress), "Outgo exchange not allowed");
+        require(to.isAllowIncomeExchange(address(this)), "Income exchange not allowed");
+
+        uint256 targetTokenAmount = Math.mulDiv(
+            Math.mulDiv(
+                Math.mulDiv(amountToSwap, 10 ** 18, fromToken.exchangeRate),
+                pceToken.getCurrentFactor(),
+                getCurrentFactor()
+            ),
+            Math.mulDiv(toToken.exchangeRate, to.getCurrentFactor(), INITIAL_FACTOR),
+            pceToken.getCurrentFactor()
+        );
+
+        require(targetTokenAmount > 0, "Invalid amount to swap");
+
+        super._burn(sender, displayBalanceToRawBalance(amountToSwap));
+        to.mint(sender, targetTokenAmount);
+    }
+
+    /*
+        @notice Returns the fee in this token for the meta transaction in the current block.
+    */
+    function getMetaTransactionFee() public view returns (uint256) {
+        PCETokenV10 pceToken = PCETokenV10(pceAddress);
+        uint256 pceTokenFee = pceToken.getMetaTransactionFee();
+        uint256 rate = pceToken.getSwapRate(address(this));
+        return Math.mulDiv(pceTokenFee, rate, 2**96);
+    }
+
+    /*
+        @notice Returns the fee in this token for the meta transaction with custom baseFee.
+    */
+    function getMetaTransactionFeeWithBaseFee(uint256 _baseFee) public view returns (uint256) {
+        PCETokenV10 pceToken = PCETokenV10(pceAddress);
+        uint256 pceTokenFee = pceToken.getMetaTransactionFeeWithBaseFee(_baseFee);
+        uint256 rate = pceToken.getSwapRate(address(this));
+        return Math.mulDiv(pceTokenFee, rate, 2**96);
+    }
+
+    function transferWithAuthorization(
+        address from, address to, uint256 displayAmount, uint256 validAfter, uint256 validBefore, bytes32 nonce, uint8 v, bytes32 r, bytes32 s
+    )
+        public
+        override
+    {
+        updateFactorIfNeeded();
+        uint256 rawBalance = super.balanceOf(from);
+        uint256 rawAmount = displayBalanceToRawBalance(displayAmount);
+        uint256 displayFee = getMetaTransactionFee();
+        uint256 rawFee = displayBalanceToRawBalance(displayFee);
+        _transferWithAuthorization(from, to, displayAmount, validAfter, validBefore, nonce, v, r, s, rawAmount);
+
+        super._transfer(from, _msgSender(), rawFee);
+
+        emit MetaTransactionFeeCollected(from, _msgSender(), displayFee, rawFee);
+
+        _mintArigatoCreation(from, rawAmount, rawBalance, 1);
+    }
+
+    function transferFromWithAuthorization(
+        address spender, address from, address to, uint256 displayAmount, uint256 validAfter, uint256 validBefore, bytes32 nonce, uint8 v, bytes32 r, bytes32 s
+    )
+        public
+    {
+        updateFactorIfNeeded();
+        uint256 rawBalance = super.balanceOf(from);
+        uint256 rawAmount = displayBalanceToRawBalance(displayAmount);
+        uint256 displayFee = getMetaTransactionFee();
+        uint256 rawFee = displayBalanceToRawBalance(displayFee);
+
+        require(block.timestamp > validAfter, "Not yet valid");
+        require(block.timestamp < validBefore, "Authorization expired");
+        require(!_authorizationStates[spender][nonce], "Authorization used");
+        require(rawBalance >= (rawAmount + rawFee), "Insufficient balance");
+        require(_infinityApproveFlags[from][spender] || super.allowance(from, spender) >= rawAmount, "Insufficient allowance");
+
+        bytes memory data = abi.encode(
+            TRANSFER_FROM_WITH_AUTHORIZATION_TYPEHASH,
+            spender,
+            from,
+            to,
+            displayAmount,
+            validAfter,
+            validBefore,
+            nonce
+        );
+        bytes32 digest = keccak256(abi.encodePacked(
+            "\x19\x01",
+            this.DOMAIN_SEPARATOR(),
+            keccak256(data)
+        ));
+
+        require(
+            ecrecover(digest, v, r, s) == spender,
+            "Invalid signature"
+        );
+
+        _authorizationStates[spender][nonce] = true;
+        emit AuthorizationUsed(spender, nonce);
+
+        _spendAllowance(from, spender, rawAmount);
+        super._transfer(from, to, rawAmount);
+        super._transfer(from, _msgSender(), rawFee);
+
+        emit MetaTransactionFeeCollected(from, _msgSender(), displayFee, rawFee);
+        _mintArigatoCreation(from, rawAmount, rawBalance, 1);
+    }
+
+    /*
+        @notice Returns the total balance that can be swapped to PCE today
+        The balance is 0.01 times the total supply at UTC 0
+    */
+    function getTodaySwapableToPCEBalance() public view returns (uint256) {
+        PCETokenV10 pceToken = PCETokenV10(pceAddress);
+
+        return rawBalanceToDisplayBalance(Math.mulDiv(midnightTotalSupply, pceToken.swapableToPCERate(), BP_BASE));
+    }
+
+    /*
+        @notice Returns the total balance that can be swapped to PCE today for the individual
+        The balance is 0.01 times the balance of the individual at UTC 0
+    */
+    function getTodaySwapableToPCEBalanceForIndividual(address checkAddress) public view returns (uint256) {
+        PCETokenV10 pceToken = PCETokenV10(pceAddress);
+
+        AccountInfo memory accountInfo = _accountInfos[checkAddress];
+        uint256 individualRate = pceToken.swapableToPCEIndividualRate();
+        uint256 rawAmount = Math.mulDiv(accountInfo.midnightBalance, individualRate, BP_BASE);
+
+        return rawBalanceToDisplayBalance(rawAmount);
+    }
+
+    function setInfinityApproveFlag(address spender, bool flag) public {
+        _infinityApproveFlags[_msgSender()][spender] = flag;
+        emit InfinityApproveFlagSet(_msgSender(), spender, flag);
+    }
+
+    function getInfinityApproveFlag(address owner, address spender) public view returns (bool) {
+        return _infinityApproveFlags[owner][spender];
+    }
+
+    function setInfinityApproveFlagWithAuthorization(
+        address owner, address spender, bool flag, uint256 validAfter, uint256 validBefore, bytes32 nonce, uint8 v, bytes32 r, bytes32 s
+    )
+        public
+    {
+        updateFactorIfNeeded();
+        uint256 displayFee = getMetaTransactionFee();
+        uint256 rawFee = displayBalanceToRawBalance(displayFee);
+
+        require(block.timestamp > validAfter, "Not yet valid");
+        require(block.timestamp < validBefore, "Authorization expired");
+        require(!_authorizationStates[owner][nonce], "Authorization used");
+        require(super.balanceOf(owner) >= (rawFee), "Insufficient balance");
+
+        bytes memory data = abi.encode(
+            SET_INFINITY_APPROVE_FLAG_WITH_AUTHORIZATION_TYPEHASH,
+            owner,
+            spender,
+            flag,
+            validAfter,
+            validBefore,
+            nonce
+        );
+        bytes32 digest = keccak256(abi.encodePacked(
+            "\x19\x01",
+            this.DOMAIN_SEPARATOR(),
+            keccak256(data)
+        ));
+
+        require(
+            ecrecover(digest, v, r, s) == owner,
+            "Invalid signature"
+        );
+
+        _authorizationStates[owner][nonce] = true;
+        emit AuthorizationUsed(owner, nonce);
+
+        _infinityApproveFlags[owner][spender] = flag;
+        emit InfinityApproveFlagSet(owner, spender, flag);
+
+        // Collect meta transaction fee from owner
+        super._transfer(owner, _msgSender(), rawFee);
+        emit MetaTransactionFeeCollected(owner, _msgSender(), displayFee, rawFee);
+    }
+
+    // Voucher functions
+    function registerVoucherIssuance(
+        string memory issuanceId,
+        string memory _name,
+        uint256 _amountPerClaim,
+        uint256 _countLimitPerUser,
+        uint256 _totalAmountLimit,
+        uint256 _initialFunds,
+        uint256 _startTime,
+        uint256 _endTime,
+        bytes32 _merkleRoot,
+        string memory _ipfsCid  // Optional IPFS CID (pass empty string if not needed)
+    )
+        external
+    {
+        uint256 initialFundsRawAmount = displayBalanceToRawBalance(_initialFunds);
+        require(super.balanceOf(_msgSender()) >= initialFundsRawAmount, "Insufficient balance");
+
+        VoucherSystem.registerIssuance(
+            _voucherStorage,
+            issuanceId,
+            _name,
+            _amountPerClaim,
+            _countLimitPerUser,
+            _totalAmountLimit,
+            initialFundsRawAmount,
+            _startTime,
+            _endTime,
+            _merkleRoot,
+            _msgSender(),
+            _ipfsCid
+        );
+
+        // Lock tokens from issuer
+        super._transfer(_msgSender(), address(this), initialFundsRawAmount);
+    }
+
+    function claimVoucher(string memory issuanceId, string memory code, bytes32[] calldata proof) external {
+        VoucherSystem.VoucherIssuance memory issuance = VoucherSystem.getIssuance(_voucherStorage, issuanceId);
+        uint256 rawClaimAmount = displayBalanceToRawBalance(issuance.amountPerClaim);
+
+        VoucherSystem.claim(_voucherStorage, issuanceId, code, proof, _msgSender(), rawClaimAmount);
+
+        // Transfer tokens from contract to claimer
+        super._transfer(address(this), _msgSender(), rawClaimAmount);
+    }
+
+    function claimVoucherWithAuthorization(
+        address claimer,
+        string memory issuanceId,
+        string memory code,
+        bytes32[] calldata proof,
+        uint256 validAfter,
+        uint256 validBefore,
+        bytes32 nonce,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    )
+        external
+    {
+        updateFactorIfNeeded();
+        uint256 displayFee = getMetaTransactionFee();
+        uint256 rawFee = displayBalanceToRawBalance(displayFee);
+
+        require(block.timestamp > validAfter, "Not yet valid");
+        require(block.timestamp < validBefore, "Authorization expired");
+        require(!_authorizationStates[claimer][nonce], "Authorization used");
+
+        bytes memory data = abi.encode(
+            CLAIM_WITH_AUTHORIZATION_TYPEHASH,
+            claimer,
+            keccak256(bytes(issuanceId)),  // Note: string型は自動的にハッシュ化されるため、この実装が必要
+            keccak256(bytes(code)),         // Note: string型は自動的にハッシュ化されるため、この実装が必要
+            validAfter,
+            validBefore,
+            nonce
+        );
+        bytes32 digest = keccak256(abi.encodePacked("\x19\x01", this.DOMAIN_SEPARATOR(), keccak256(data)));
+
+        require(ecrecover(digest, v, r, s) == claimer, "Invalid signature");
+
+        _authorizationStates[claimer][nonce] = true;
+        emit AuthorizationUsed(claimer, nonce);
+
+        // Get claim amount and convert to raw balance
+        VoucherSystem.VoucherIssuance memory issuance = VoucherSystem.getIssuance(_voucherStorage, issuanceId);
+        uint256 rawClaimAmount = displayBalanceToRawBalance(issuance.amountPerClaim);
+
+        // Check if claim amount is greater than meta transaction fee
+        require(rawClaimAmount > rawFee, "Claim amount must be greater than fee");
+
+        // Claim from voucher
+        VoucherSystem.claim(_voucherStorage, issuanceId, code, proof, claimer, rawClaimAmount);
+
+        // Calculate amount after deducting fee
+        uint256 amountAfterFee = rawClaimAmount - rawFee;
+
+        // Transfer amount after fee to claimer
+        super._transfer(address(this), claimer, amountAfterFee);
+
+        // Collect meta transaction fee from claimed amount
+        super._transfer(address(this), _msgSender(), rawFee);
+        emit MetaTransactionFeeCollected(claimer, _msgSender(), displayFee, rawFee);
+    }
+
+    function getVoucherIssuanceInfo(string memory issuanceId)
+        external
+        view
+        returns (VoucherIssuanceInfo memory)
+    {
+        VoucherSystem.VoucherIssuance memory issuance = VoucherSystem.getIssuance(_voucherStorage, issuanceId);
+        (uint256 remainingRawAmount, uint256 claimedRawAmount, uint256 claimedDisplayAmount, uint256 totalClaimCount) =
+            VoucherSystem.getFundsInfo(_voucherStorage, issuanceId);
+
+        return VoucherIssuanceInfo({
+            issuanceId: issuance.issuanceId,
+            owner: issuance.owner,
+            name: issuance.name,
+            amountPerClaim: issuance.amountPerClaim,
+            countLimitPerUser: issuance.countLimitPerUser,
+            totalAmountLimit: issuance.totalAmountLimit,
+            startTime: issuance.startTime,
+            endTime: issuance.endTime,
+            merkleRoot: issuance.merkleRoot,
+            isActive: issuance.isActive,
+            remainingAmount: rawBalanceToDisplayBalance(remainingRawAmount),
+            claimedAmount: rawBalanceToDisplayBalance(claimedRawAmount),
+            claimedDisplayAmount: claimedDisplayAmount,
+            totalClaimCount: totalClaimCount,
+            ipfsCid: issuance.ipfsCid
+        });
+    }
+
+    function getVoucherIssuanceIds() external view returns (string[] memory) {
+        return VoucherSystem.getIssuanceIds(_voucherStorage);
+    }
+
+    function canClaimVoucher(
+        string memory issuanceId,
+        string memory code,
+        bytes32[] calldata proof,
+        address claimer
+    )
+        external
+        view
+        returns (bool, uint8)
+    {
+        VoucherSystem.VoucherIssuance memory issuance = VoucherSystem.getIssuance(_voucherStorage, issuanceId);
+        uint256 claimRawAmount = displayBalanceToRawBalance(issuance.amountPerClaim);
+        return VoucherSystem.canClaim(_voucherStorage, issuanceId, code, proof, claimer, claimRawAmount);
+    }
+
+    function addVoucherFunds(string memory issuanceId, uint256 _amount) external {
+        uint256 rawAmount = displayBalanceToRawBalance(_amount);
+        require(super.balanceOf(_msgSender()) >= rawAmount, "Insufficient balance");
+
+        VoucherSystem.addFunds(_voucherStorage, issuanceId, rawAmount, _msgSender());
+
+        // Transfer tokens from sender to contract
+        super._transfer(_msgSender(), address(this), rawAmount);
+    }
+
+    function withdrawVoucherFunds(string memory issuanceId, uint256 _amount) external {
+        uint256 rawAmount = displayBalanceToRawBalance(_amount);
+
+        uint256 withdrawnRawAmount = VoucherSystem.withdrawFunds(_voucherStorage, issuanceId, rawAmount, _msgSender());
+
+        // Transfer tokens from contract to sender
+        super._transfer(address(this), _msgSender(), withdrawnRawAmount);
+    }
+
+    function terminateVoucherIssuance(string memory issuanceId) external {
+        uint256 remainingRawAmount = VoucherSystem.terminateIssuance(_voucherStorage, issuanceId, _msgSender());
+
+        // Transfer remaining tokens from contract to sender
+        if (remainingRawAmount > 0) {
+            super._transfer(address(this), _msgSender(), remainingRawAmount);
+        }
+    }
+
+    function setTokenSettings(
+        uint256 _decreaseIntervalDays,
+        uint16 _afterDecreaseBp,
+        uint16 _maxIncreaseOfTotalSupplyBp,
+        uint16 _maxIncreaseBp,
+        uint16 _maxUsageBp,
+        uint16 _changeBp,
+        ExchangeAllowMethod _incomeExchangeAllowMethod,
+        ExchangeAllowMethod _outgoExchangeAllowMethod,
+        address[] calldata _incomeTargetTokens,
+        address[] calldata _outgoTargetTokens
+    )
+        public
+        override
+        onlyOwner
+    {
+        super.setTokenSettings(
+            _decreaseIntervalDays,
+            _afterDecreaseBp,
+            _maxIncreaseOfTotalSupplyBp,
+            _maxIncreaseBp,
+            _maxUsageBp,
+            _changeBp,
+            _incomeExchangeAllowMethod,
+            _outgoExchangeAllowMethod,
+            _incomeTargetTokens,
+            _outgoTargetTokens
+        );
+    }
+
+    function version() public pure returns (string memory) {
+        return "1.0.10";
+    }
+}

--- a/src/PCETokenV10.sol
+++ b/src/PCETokenV10.sol
@@ -1,0 +1,386 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import { BeaconProxy } from "@openzeppelin/contracts/proxy/beacon/BeaconProxy.sol";
+import { UUPSUpgradeable } from "@openzeppelin/contracts/proxy/utils/UUPSUpgradeable.sol";
+import { ERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol";
+import { OwnableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import { Initializable } from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import { ERC20BurnableUpgradeable } from
+    "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC20BurnableUpgradeable.sol";
+import { Clones } from "@openzeppelin/contracts/proxy/Clones.sol";
+import { PCECommunityTokenV10 } from "./PCECommunityTokenV10.sol";
+import { Utils } from "./lib/Utils.sol";
+import { ExchangeAllowMethod } from "./lib/Enum.sol";
+import { NativeMetaTransaction } from "./lib/polygon/NativeMetaTransaction.sol";
+import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
+/// @custom:oz-upgrades-from PCETokenV4
+
+contract PCETokenV10 is
+    UUPSUpgradeable,
+    Initializable,
+    ERC20Upgradeable,
+    OwnableUpgradeable,
+    ERC20BurnableUpgradeable,
+    NativeMetaTransaction
+{
+    uint160 public nativeTokenToPceTokenRate;
+    uint256 public metaTransactionGas;
+    uint256 public metaTransactionPriorityFee;
+
+    // Daily swap rate from community token to PCE in basis points
+    uint256 public swapableToPCERate;
+    // Individual daily swap limit from community token to PCE in basis points
+    uint256 public swapableToPCEIndividualRate;
+
+    address private _communityTokenAddress;
+    address[] public tokens;
+    mapping(address deployedAddress => Utils.LocalToken localToken) public localTokens;
+
+    address public polygonChainManager;
+
+    event TokenCreated(
+        address indexed tokenAddress, address indexed creator, uint256 pcetokenAmount, uint256 newTokenAmount
+    );
+    event TokensSwappedToLocalToken(
+        address indexed from, address indexed toToken, uint256 pceTokenAmount, uint256 targetTokenAmount
+    );
+    event TokensSwappedFromLocalToken(
+        address indexed to, address indexed fromToken, uint256 targetTokenAmount, uint256 pceTokenAmount
+    );
+
+    uint256 public constant INITIAL_FACTOR = 10 ** 18;
+    // 998/1000 = 0.02
+    uint256 public constant DECREASE_RATE = 998 * (10 ** 18);
+    uint256 public constant DECREASE_RATE_BASE = 1000 * (10 ** 18);
+
+    uint256 public epochTime;
+    uint256 public lastDecreaseTime;
+    uint256 public lastModifiedFactor;
+
+    function initialize() public initializer {
+        __ERC20_init("PCE Token", "PCE");
+        __Ownable_init(_msgSender());
+        __ERC20Burnable_init();
+        _initializeEIP712("PCE Token");
+        epochTime = block.timestamp;
+        lastDecreaseTime = block.timestamp;
+        lastModifiedFactor = INITIAL_FACTOR;
+    }
+
+    function getLocalToken(address communityToken) public view returns (Utils.LocalToken memory) {
+        return localTokens[communityToken];
+    }
+
+    function getCurrentFactor() public view returns (uint256) {
+        if (lastModifiedFactor == 0) {
+            return 0;
+        }
+        if (hasDecreaseTimeWithin(lastDecreaseTime, block.timestamp)) {
+            return Math.mulDiv(lastModifiedFactor, DECREASE_RATE, DECREASE_RATE_BASE);
+        } else {
+            return lastModifiedFactor;
+        }
+    }
+
+    function updateFactorIfNeeded() public {
+        if (lastDecreaseTime == block.timestamp) {
+            return;
+        }
+
+        uint256 currentFactor = getCurrentFactor();
+        if (currentFactor != lastModifiedFactor) {
+            lastModifiedFactor = currentFactor;
+            lastDecreaseTime = block.timestamp;
+        }
+    }
+
+    function transfer(address receiver, uint256 balance) public override returns (bool) {
+        updateFactorIfNeeded();
+        return super.transfer(receiver, balance);
+    }
+
+    function transferFrom(address sender, address receiver, uint256 balance) public override returns (bool) {
+        updateFactorIfNeeded();
+        return super.transferFrom(sender, receiver, balance);
+    }
+
+    function approve(address spender, uint256 balance) public override returns (bool) {
+        updateFactorIfNeeded();
+        return super.approve(spender, balance);
+    }
+
+    function mint(address to, uint256 balance) external onlyOwner {
+        updateFactorIfNeeded();
+        _mint(to, balance);
+    }
+
+    function getTokens() public view returns (address[] memory) {
+        return tokens;
+    }
+
+    function setCommunityTokenAddress(address communityTokenAddress) external onlyOwner {
+        _communityTokenAddress = communityTokenAddress;
+    }
+
+    function createToken(
+        string memory name,
+        string memory symbol,
+        uint256 amountToExchange,
+        uint256 dilutionFactor,
+        uint256 decreaseIntervalDays,
+        uint16 afterDecreaseBp,
+        uint16 maxIncreaseOfTotalSupplyBp,
+        uint16 maxIncreaseBp,
+        uint16 maxUsageBp,
+        uint16 changeBp,
+        ExchangeAllowMethod incomeExchangeAllowMethod,
+        ExchangeAllowMethod outgoExchangeAllowMethod,
+        address[] calldata incomeTargetTokens,
+        address[] calldata outgoTargetTokens
+    )
+        public
+    {
+        require(amountToExchange > 0, "Amount must be > 0");
+        require(balanceOf(_msgSender()) >= amountToExchange, "Insufficient PCEToken bal.");
+        require(dilutionFactor >= 10 ** 17 && dilutionFactor <= 10 ** 21, "Dilution factor 0.1-1000");
+        require(afterDecreaseBp <= 10_000, "After decrease bp <= 10000");
+
+        updateFactorIfNeeded();
+
+        BeaconProxy proxy = new BeaconProxy(
+            _communityTokenAddress,
+            abi.encodeWithSelector(
+                PCECommunityTokenV10(address(0)).initialize.selector,
+                name,
+                symbol,
+                lastModifiedFactor
+            )
+        );
+        address newTokenAddress = address(proxy);
+        PCECommunityTokenV10 newToken = PCECommunityTokenV10(newTokenAddress);
+        newToken.setTokenSettings(
+            decreaseIntervalDays,
+            afterDecreaseBp,
+            maxIncreaseOfTotalSupplyBp,
+            maxIncreaseBp,
+            maxUsageBp,
+            changeBp,
+            incomeExchangeAllowMethod,
+            outgoExchangeAllowMethod,
+            incomeTargetTokens,
+            outgoTargetTokens
+        );
+
+        uint256 newTokenAmount = (amountToExchange * dilutionFactor) / INITIAL_FACTOR;
+        _transfer(_msgSender(), address(this), amountToExchange);
+        newToken.mint(_msgSender(), newTokenAmount);
+
+        localTokens[newTokenAddress] = Utils.LocalToken(true, dilutionFactor, amountToExchange);
+        tokens.push(newTokenAddress);
+
+        newToken.transferOwnership(_msgSender());
+
+        emit TokenCreated(newTokenAddress, _msgSender(), amountToExchange, newTokenAmount);
+    }
+
+    function getDepositedPCETokens(address communityToken) public view returns (uint256) {
+        require(localTokens[communityToken].isExists, "Target token not found");
+
+        return localTokens[communityToken].depositedPCEToken;
+    }
+
+    function getExchangeRate(address communityToken) public view returns (uint256) {
+        require(localTokens[communityToken].isExists, "Target token not found");
+
+        return localTokens[communityToken].exchangeRate;
+    }
+
+    function getSwapRate(address toToken) public view returns (uint256) {
+        require(localTokens[toToken].isExists, "Target token not found");
+
+        PCECommunityTokenV10 target = PCECommunityTokenV10(toToken);
+
+        return (((localTokens[toToken].exchangeRate << 96) / INITIAL_FACTOR) * target.getCurrentFactor())
+            / getCurrentFactor();
+    }
+
+    /**
+     * @notice Calculate the exchange rate between two community tokens
+     * @param fromToken The source community token address
+     * @param toToken The target community token address
+     * @return The exchange rate (without shift)
+     *
+     * Amount of toToken received when swapping 1 fromToken = 1 × exchangeRate
+     */
+    function getSwapRateBetweenTokens(address fromToken, address toToken) public view returns (uint256) {
+        require(localTokens[fromToken].isExists, "From token not found");
+        require(localTokens[toToken].isExists, "Target token not found");
+
+        PCECommunityTokenV10 fromTarget = PCECommunityTokenV10(fromToken);
+        PCECommunityTokenV10 toTarget = PCECommunityTokenV10(toToken);
+
+        uint256 exchangeRateRatio = Math.mulDiv(
+            localTokens[toToken].exchangeRate,
+            INITIAL_FACTOR,
+            localTokens[fromToken].exchangeRate
+        );
+
+        uint256 currentFactorRatio = Math.mulDiv(
+            toTarget.getCurrentFactor(),
+            INITIAL_FACTOR,
+            fromTarget.getCurrentFactor()
+        );
+
+        uint256 result = Math.mulDiv(exchangeRateRatio, currentFactorRatio, INITIAL_FACTOR);
+        return result;
+    }
+
+    function swapToLocalToken(address toToken, uint256 amountToSwap) public {
+        updateFactorIfNeeded();
+        require(localTokens[toToken].isExists, "Target token not found");
+        require(balanceOf(_msgSender()) >= amountToSwap, "Not enough PCEToken balance");
+
+        PCECommunityTokenV10 target = PCECommunityTokenV10(toToken);
+        target.updateFactorIfNeeded();
+
+        uint256 targetTokenAmount = Math.mulDiv(
+            Math.mulDiv(amountToSwap, localTokens[toToken].exchangeRate, INITIAL_FACTOR),
+            target.getCurrentFactor(),
+            lastModifiedFactor
+        );
+        require(targetTokenAmount > 0, "Invalid amount to swap");
+
+        _transfer(_msgSender(), address(this), amountToSwap);
+        target.mint(_msgSender(), targetTokenAmount);
+
+        localTokens[toToken].depositedPCEToken = localTokens[toToken].depositedPCEToken + amountToSwap;
+
+        emit TokensSwappedToLocalToken(_msgSender(), toToken, amountToSwap, targetTokenAmount);
+    }
+
+    function swapFromLocalToken(address fromToken, uint256 amountToSwap) public {
+        updateFactorIfNeeded();
+        require(localTokens[fromToken].isExists, "Target token not found");
+
+        PCECommunityTokenV10 target = PCECommunityTokenV10(fromToken);
+        target.updateFactorIfNeeded();
+
+        require(target.balanceOf(_msgSender()) >= amountToSwap, "Insufficient balance");
+
+        uint256 pcetokenAmount = Math.mulDiv(
+            Math.mulDiv(amountToSwap, INITIAL_FACTOR, localTokens[fromToken].exchangeRate),
+            lastModifiedFactor,
+            target.getCurrentFactor()
+        );
+        require(pcetokenAmount > 0, "Target token deposit low");
+
+        require(target.getTodaySwapableToPCEBalance() >= amountToSwap, "Insufficient balance");
+        require(target.getTodaySwapableToPCEBalanceForIndividual(_msgSender()) >= amountToSwap, "Insufficient balance");
+
+        target.burnByPCEToken(_msgSender(), amountToSwap);
+        _transfer(address(this), _msgSender(), pcetokenAmount);
+
+        localTokens[fromToken].depositedPCEToken = localTokens[fromToken].depositedPCEToken - pcetokenAmount;
+
+        emit TokensSwappedFromLocalToken(_msgSender(), fromToken, amountToSwap, pcetokenAmount);
+    }
+
+    /*
+        @notice return rate shifted 96bit.
+                (NativeToken * rate) >> 96 = PceToken
+                (PceToken * ( 1 << 96 ) ) / rate = NativeToken
+    */
+    function getNativeTokenToPceTokenRate() public view returns (uint256) {
+        // TODO: Get the rate dynamically from Oracle or defi such as uniswap.
+        return nativeTokenToPceTokenRate;
+    }
+
+    function setNativeTokenToPceTokenRate(uint160 _nativeTokenToPceTokenRate) public onlyOwner {
+        nativeTokenToPceTokenRate = _nativeTokenToPceTokenRate;
+    }
+
+    function setMetaTransactionGas(uint256 _metaTransactionGas) public onlyOwner {
+        metaTransactionGas = _metaTransactionGas;
+    }
+
+    function setMetaTransactionPriorityFee(uint256 _metaTransactionPriorityFee) public onlyOwner {
+        metaTransactionPriorityFee = _metaTransactionPriorityFee;
+    }
+
+    function getBlockBaseFee() public view returns (uint256) {
+        return block.basefee;
+    }
+
+    /*
+        @notice Returns the fee in PCE token for the meta transaction in the current block.
+    */
+    function getMetaTransactionFee() public view returns (uint256) {
+        uint256 nativeTokenFee = metaTransactionGas * (block.basefee + metaTransactionPriorityFee);
+        return Math.mulDiv(nativeTokenFee, getNativeTokenToPceTokenRate(), 2**96);
+    }
+
+    /*
+        @notice Returns the fee in PCE token for the meta transaction with custom baseFee.
+    */
+    function getMetaTransactionFeeWithBaseFee(uint256 _baseFee) public view returns (uint256) {
+        uint256 nativeTokenFee = metaTransactionGas * (_baseFee + metaTransactionPriorityFee);
+        return Math.mulDiv(nativeTokenFee, getNativeTokenToPceTokenRate(), 2**96);
+    }
+
+    function hasDecreaseTimeWithin(uint256 _start, uint256 _end) public pure returns (bool) {
+        return isWednesdayBetween(_start, _end);
+    }
+
+    function getElapsedMinutes(uint256 _start, uint256 _end) public pure returns (uint256) {
+        require(_start <= _end, "Start time must be <= end");
+
+        uint256 elapsedSeconds = _end - _start;
+        uint256 elapsedMinutes = elapsedSeconds / 60;
+
+        return elapsedMinutes;
+    }
+
+    function isWednesdayBetween(uint256 start, uint256 end) public pure returns (bool) {
+        require(start <= end, "Start time must be <= end");
+        if (start == end) {
+            return false;
+        }
+        uint256 startDay = start / 1 days;
+        uint256 endDay = end / 1 days;
+        if (startDay == endDay) {
+            return false;
+        }
+
+        // 0 = Thursday, 1 = Friday, 2 = Saturday, ..., 6 = Wednesday
+        uint256 startWeekday = startDay % 7;
+        uint256 endWeekday = endDay % 7;
+
+        if (startWeekday != 6 && startWeekday >= endWeekday) {
+            return true;
+        } else if (endWeekday == 6) {
+            return true;
+        } else {
+            uint256 startWeek = startDay / 7;
+            uint256 endWeek = endDay / 7;
+            return startWeek != endWeek;
+        }
+    }
+
+    // for polygon bridge
+    function deposit(address user, bytes calldata depositData) external {
+        require(msg.sender == polygonChainManager, "Only polygon chain manager can call this function");
+        uint256 amount = abi.decode(depositData, (uint256));
+        _mint(user, amount);
+    }
+
+    function withdraw(uint256 amount) external {
+        _burn(_msgSender(), amount);
+    }
+
+    function _authorizeUpgrade(address newImplementation) internal virtual override onlyOwner { }
+
+    function version() public pure returns (string memory) {
+        return "1.0.10";
+    }
+}

--- a/src/PCETokenV10.sol
+++ b/src/PCETokenV10.sol
@@ -14,7 +14,7 @@ import { Utils } from "./lib/Utils.sol";
 import { ExchangeAllowMethod } from "./lib/Enum.sol";
 import { NativeMetaTransaction } from "./lib/polygon/NativeMetaTransaction.sol";
 import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
-/// @custom:oz-upgrades-from PCETokenV4
+/// @custom:oz-upgrades-from PCETokenV9
 
 contract PCETokenV10 is
     UUPSUpgradeable,
@@ -50,7 +50,7 @@ contract PCETokenV10 is
     );
 
     uint256 public constant INITIAL_FACTOR = 10 ** 18;
-    // 998/1000 = 0.02
+    // 998/1000 = 0.998 (represents a 0.2% decrease)
     uint256 public constant DECREASE_RATE = 998 * (10 ** 18);
     uint256 public constant DECREASE_RATE_BASE = 1000 * (10 ** 18);
 

--- a/test/PCEV10.t.sol
+++ b/test/PCEV10.t.sol
@@ -198,7 +198,7 @@ contract PCEV10Test is Test {
         // Wednesday is day 6 in the epoch (0=Thursday)
         // Unix epoch starts on Thursday, Jan 1, 1970
 
-        // Pick a Monday and a Thursday in the same week (no Wednesday between)
+        // Pick a Monday and a Tuesday in the same week (no Wednesday between)
         uint256 monday = 1704067200; // 2024-01-01 Monday 00:00 UTC
         uint256 tuesday = monday + 1 days;
 
@@ -230,11 +230,8 @@ contract PCEV10Test is Test {
         // Find next Wednesday from current block.timestamp
         uint256 currentDay = block.timestamp / 1 days;
         uint256 currentWeekday = currentDay % 7; // 0=Thu, 6=Wed
-        uint256 daysUntilWednesday;
-        if (currentWeekday <= 6) {
-            daysUntilWednesday = (6 - currentWeekday) % 7;
-            if (daysUntilWednesday == 0) daysUntilWednesday = 7;
-        }
+        uint256 daysUntilWednesday = (6 - currentWeekday) % 7;
+        if (daysUntilWednesday == 0) daysUntilWednesday = 7;
 
         // Warp to just before Wednesday
         uint256 beforeWednesday = block.timestamp + (daysUntilWednesday * 1 days) - 1 hours;

--- a/test/PCEV10.t.sol
+++ b/test/PCEV10.t.sol
@@ -1,0 +1,262 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import {Test, console2} from "forge-std/Test.sol";
+import {PCECommunityTokenV10} from "../src/PCECommunityTokenV10.sol";
+import {PCEToken} from "../src/PCEToken.sol";
+import {PCETokenV10} from "../src/PCETokenV10.sol";
+import {ExchangeAllowMethod} from "../src/lib/Enum.sol";
+import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
+import {Utils} from "../src/lib/Utils.sol";
+
+// Minimal Beacon for testing
+contract MinimalBeaconV10 {
+    address public implementation;
+    address public owner;
+
+    constructor(address initialImplementation) {
+        implementation = initialImplementation;
+        owner = msg.sender;
+    }
+
+    function upgradeTo(address newImplementation) public {
+        require(msg.sender == owner, "Ownable: caller is not the owner");
+        implementation = newImplementation;
+    }
+}
+
+// Minimal UUPS Proxy for testing
+contract MinimalUUPSProxyV10 {
+    address public implementation;
+    address public owner;
+
+    constructor(address initialImplementation) {
+        implementation = initialImplementation;
+        owner = msg.sender;
+    }
+
+    function upgradeTo(address newImplementation) public {
+        require(msg.sender == owner, "Ownable: caller is not the owner");
+        implementation = newImplementation;
+    }
+
+    fallback() external payable {
+        _delegate(implementation);
+    }
+
+    receive() external payable {
+        _delegate(implementation);
+    }
+
+    function _delegate(address _implementation) internal virtual {
+        assembly {
+            calldatacopy(0, 0, calldatasize())
+            let result := delegatecall(gas(), _implementation, 0, calldatasize(), 0, 0)
+            returndatacopy(0, 0, returndatasize())
+            switch result
+            case 0 { revert(0, returndatasize()) }
+            default { return(0, returndatasize()) }
+        }
+    }
+}
+
+contract PCEV10Test is Test {
+    PCETokenV10 public pceToken;
+    PCECommunityTokenV10 public token;
+    MinimalBeaconV10 public pceCommunityTokenBeacon;
+    address public owner;
+    address public user1;
+    address public user2;
+
+    function setUp() public {
+        owner = address(this);
+        user1 = address(0x1);
+        user2 = address(0x2);
+
+        vm.startPrank(owner);
+
+        PCECommunityTokenV10 communityImpl = new PCECommunityTokenV10();
+        PCEToken pceTokenV1 = new PCEToken();
+        PCETokenV10 pceTokenV10Impl = new PCETokenV10();
+
+        pceCommunityTokenBeacon = new MinimalBeaconV10(address(communityImpl));
+
+        MinimalUUPSProxyV10 pceTokenProxy = new MinimalUUPSProxyV10(address(pceTokenV1));
+        PCEToken(address(pceTokenProxy)).initialize(
+            "PCE Token",
+            "PCE",
+            address(pceCommunityTokenBeacon),
+            address(0x687C1D2dd0F422421BeF7aC2a52f50e858CAA867)
+        );
+
+        pceTokenProxy.upgradeTo(address(pceTokenV10Impl));
+        pceToken = PCETokenV10(address(pceTokenProxy));
+
+        pceToken.mint(owner, 10000 ether);
+
+        address[] memory incomeTargetTokens = new address[](0);
+        address[] memory outgoTargetTokens = new address[](0);
+
+        pceToken.createToken(
+            "Test Community Token",
+            "TCT",
+            1000 ether,
+            1 ether,   // 1:1 dilution
+            1,         // decrease interval days
+            9800,      // after decrease bp (98%)
+            1000,      // max increase of total supply bp
+            500,       // max increase bp
+            1000,      // max usage bp
+            100,       // change bp
+            ExchangeAllowMethod.All,
+            ExchangeAllowMethod.All,
+            incomeTargetTokens,
+            outgoTargetTokens
+        );
+
+        vm.stopPrank();
+
+        address[] memory tokens = pceToken.getTokens();
+        token = PCECommunityTokenV10(tokens[0]);
+    }
+
+    function testSwapFromLocalToken() public {
+        // First swap PCE -> community token (swapToLocalToken)
+        vm.startPrank(owner);
+        uint256 swapAmount = 100 ether;
+        pceToken.swapToLocalToken(address(token), swapAmount);
+
+        uint256 communityBalance = token.balanceOf(owner);
+        assertTrue(communityBalance > 0, "Should have community tokens after swap");
+        console2.log("Community token balance after swapTo:", communityBalance);
+
+        // Set swapable rates (required for swapFromLocalToken)
+        // Need to call as owner of PCEToken
+        // swapableToPCERate and swapableToPCEIndividualRate need to be set
+
+        // Advance time by 1 day so midnightBalance gets set
+        vm.warp(block.timestamp + 1 days);
+
+        // Trigger midnightBalance update by doing a small transfer
+        token.transfer(user1, 1 ether);
+
+        // Advance another day
+        vm.warp(block.timestamp + 1 days);
+
+        // Now try swapFromLocalToken - should work without needing approve
+        uint256 swapBackAmount = 10 ether;
+        uint256 pceBalanceBefore = pceToken.balanceOf(owner);
+
+        pceToken.swapFromLocalToken(address(token), swapBackAmount);
+
+        uint256 pceBalanceAfter = pceToken.balanceOf(owner);
+        assertTrue(pceBalanceAfter > pceBalanceBefore, "PCE balance should increase after swap from local");
+        console2.log("PCE balance increased by:", pceBalanceAfter - pceBalanceBefore);
+
+        vm.stopPrank();
+    }
+
+    function testSwapFromLocalTokenWithoutApprove() public {
+        // This test verifies that swapFromLocalToken works WITHOUT user approval
+        // (using burnByPCEToken instead of burnFrom)
+        vm.startPrank(owner);
+
+        // Swap some PCE to community tokens first
+        pceToken.swapToLocalToken(address(token), 100 ether);
+
+        // Advance time for midnightBalance
+        vm.warp(block.timestamp + 1 days);
+        token.transfer(user1, 1 ether);
+        vm.warp(block.timestamp + 1 days);
+
+        // Verify: NO approve call for pceToken on community token
+        // swapFromLocalToken should still succeed
+        uint256 communityBalanceBefore = token.balanceOf(owner);
+        pceToken.swapFromLocalToken(address(token), 5 ether);
+        uint256 communityBalanceAfter = token.balanceOf(owner);
+
+        assertTrue(communityBalanceAfter < communityBalanceBefore, "Community tokens should decrease");
+        console2.log("Community tokens burned:", communityBalanceBefore - communityBalanceAfter);
+
+        vm.stopPrank();
+    }
+
+    function testBurnByPCETokenOnlyCallableByPCEToken() public {
+        // burnByPCEToken should only be callable by the PCE token contract
+        vm.startPrank(owner);
+        token.mint(owner, 100 ether);
+        vm.stopPrank();
+
+        // Try calling burnByPCEToken from a non-PCE address (should revert)
+        vm.startPrank(user1);
+        vm.expectRevert("Only PCE token");
+        token.burnByPCEToken(owner, 10 ether);
+        vm.stopPrank();
+    }
+
+    function testHasDecreaseTimeWithinUsesWednesday() public view {
+        // Wednesday is day 6 in the epoch (0=Thursday)
+        // Unix epoch starts on Thursday, Jan 1, 1970
+
+        // Pick a Monday and a Thursday in the same week (no Wednesday between)
+        uint256 monday = 1704067200; // 2024-01-01 Monday 00:00 UTC
+        uint256 tuesday = monday + 1 days;
+
+        // No Wednesday between Monday and Tuesday
+        bool result1 = pceToken.hasDecreaseTimeWithin(monday, tuesday);
+        assertFalse(result1, "No decrease between Mon and Tue");
+
+        // Wednesday to Thursday (Wednesday was crossed)
+        uint256 wednesday = monday + 2 days; // 2024-01-03 Wednesday
+        uint256 thursday = wednesday + 1 days;
+        bool result2 = pceToken.hasDecreaseTimeWithin(wednesday, thursday);
+        assertTrue(result2, "Decrease should occur crossing Wednesday");
+    }
+
+    function testNoMinuteBasedDecrease() public {
+        // In V10, waiting just 2 minutes should NOT trigger decrease
+        // (unlike V9 where it did)
+        uint256 factorBefore = pceToken.getCurrentFactor();
+
+        // Advance 2 minutes
+        vm.warp(block.timestamp + 2 minutes);
+
+        uint256 factorAfter = pceToken.getCurrentFactor();
+        assertEq(factorBefore, factorAfter, "Factor should NOT change after 2 minutes");
+    }
+
+    function testDecreaseOnWednesday() public {
+        // Fast forward to just before Wednesday
+        // Find next Wednesday from current block.timestamp
+        uint256 currentDay = block.timestamp / 1 days;
+        uint256 currentWeekday = currentDay % 7; // 0=Thu, 6=Wed
+        uint256 daysUntilWednesday;
+        if (currentWeekday <= 6) {
+            daysUntilWednesday = (6 - currentWeekday) % 7;
+            if (daysUntilWednesday == 0) daysUntilWednesday = 7;
+        }
+
+        // Warp to just before Wednesday
+        uint256 beforeWednesday = block.timestamp + (daysUntilWednesday * 1 days) - 1 hours;
+        vm.warp(beforeWednesday);
+
+        uint256 factorBeforeWed = pceToken.getCurrentFactor();
+
+        // Warp past Wednesday
+        vm.warp(beforeWednesday + 2 hours);
+
+        uint256 factorAfterWed = pceToken.getCurrentFactor();
+
+        // Factor should have decreased
+        assertTrue(factorAfterWed < factorBeforeWed, "Factor should decrease after Wednesday");
+
+        // Check it decreased by 0.2% (factor * 998/1000)
+        uint256 expected = Math.mulDiv(factorBeforeWed, 998 * 1e18, 1000 * 1e18);
+        assertEq(factorAfterWed, expected, "Factor should decrease by 0.2%");
+    }
+
+    function testVersion() public view {
+        assertEq(pceToken.version(), "1.0.10");
+        assertEq(token.version(), "1.0.10");
+    }
+}


### PR DESCRIPTION
## Summary

- **Fix swapFromLocalToken**: Replace `burnFrom` with `burnByPCEToken` so users can swap community tokens back to PCE in a single transaction without needing a prior `approve` call
- **Fix PCE factor depreciation**: Change the depreciation trigger from every minute to weekly (on Wednesdays) as per spec

## Changes

### PCECommunityTokenV10
- Add `burnByPCEToken(address account, uint256 displayBalance)` — callable only by the PCE Token contract, burns user's community tokens without requiring approval

### PCETokenV10
- Change `target.burnFrom()` to `target.burnByPCEToken()` in `swapFromLocalToken`
- Change `hasDecreaseTimeWithin` to use `isWednesdayBetween` (every minute → weekly Wednesday)

## Background

The original prototype frontend called `approve` then `swapFromLocalToken` as two separate transactions. The current explorer app omitted the `approve` step, causing `swapFromLocalToken` to revert. V10 resolves this at the contract level so the swap completes in a single transaction.

## Test plan

- [x] `testSwapFromLocalToken` - swapFromLocalToken works correctly
- [x] `testSwapFromLocalTokenWithoutApprove` - swapFromLocalToken works without prior approve
- [x] `testBurnByPCETokenOnlyCallableByPCEToken` - burnByPCEToken reverts when called by non-PCE address
- [x] `testNoMinuteBasedDecrease` - factor does not decrease after 2 minutes
- [x] `testDecreaseOnWednesday` - factor decreases by 0.2% when crossing Wednesday
- [x] `testHasDecreaseTimeWithinUsesWednesday` - Wednesday detection logic is correct
- [x] `testVersion` - version returns 1.0.10

🤖 Generated with [Claude Code](https://claude.com/claude-code)