### PR TITLE
feat: v11, daily swap-to-PCE tracking

### DIFF
--- a/docs/v11-new-methods.md
+++ b/docs/v11-new-methods.md
@@ -1,0 +1,126 @@
+# PCECommunityTokenV11 / PCETokenV11 新規メソッド仕様
+
+## 概要
+
+V11では、コミュニティトークン → PCEトークンへの日次回収（swap）に対して**累計量のトラッキング**を導入しました。これにより、UIから「あとどれだけ回収できるか」をリアルタイムに取得できます。
+
+---
+
+## 新規 View メソッド（PCECommunityTokenV11）
+
+### `getRemainingSwapableToPCEBalance()`
+
+**本日のグローバル残り回収可能量**を返します。
+
+| 項目 | 内容 |
+|------|------|
+| 戻り値 | `uint256` — 本日あとどれだけ（display単位）全体として回収可能か |
+| ガス | view（無料） |
+| 呼び出し元制限 | なし（誰でも読める） |
+
+**計算ロジック:**
+```
+残り = 本日のグローバル限度額 − 本日の累計回収量
+```
+- 日が変わると累計回収量は自動的に0にリセットされます
+- グローバル限度額は従来の `getTodaySwapableToPCEBalance()` と同じ値です
+
+**UIでの使い方:**
+- 回収画面で「本日の残り回収枠: ○○ TCT」と表示
+- 残りが0の場合は「本日の回収上限に達しました」と表示
+
+---
+
+### `getRemainingSwapableToPCEBalanceForIndividual(address account)`
+
+**指定ユーザーの本日の個人別残り回収可能量**を返します。
+
+| 項目 | 内容 |
+|------|------|
+| 引数 | `account` — 確認対象のウォレットアドレス |
+| 戻り値 | `uint256` — そのユーザーが本日あとどれだけ（display単位）回収可能か |
+| ガス | view（無料） |
+| 呼び出し元制限 | なし（誰でも読める） |
+
+**計算ロジック:**
+```
+残り = 本日の個人限度額 − 本日のそのユーザーの累計回収量
+```
+- 日が変わると累計回収量は自動的に0にリセットされます
+- 個人限度額は従来の `getTodaySwapableToPCEBalanceForIndividual()` と同じ値です
+
+**UIでの使い方:**
+- ログインユーザーの回収画面で「あなたの残り回収枠: ○○ TCT」と表示
+- 回収フォームの最大入力値のバリデーションに使用
+- `min(グローバル残り, 個人残り)` が実際に回収可能な最大量です
+
+---
+
+## 変更メソッド（PCETokenV11）
+
+### `swapFromLocalToken(address fromToken, uint256 amountToSwap)`
+
+コミュニティトークンをPCEトークンに回収するメソッド（既存）。V11での変更点：
+
+| 項目 | V10 | V11 |
+|------|-----|-----|
+| 限度額チェック | `getTodaySwapableToPCEBalance` | `getRemainingSwapableToPCEBalance` |
+| 累計記録 | なし | あり（`recordSwapToPCE` を内部で呼出） |
+| 同日複数回呼出 | 限度額を超過可能（バグ） | 正しく制限される |
+| エラーメッセージ | `"Insufficient balance"` | `"Exceeds daily swap limit"` / `"Exceeds daily individual swap limit"` |
+
+**UIでのエラーハンドリング:**
+
+| revertメッセージ | 意味 | UIでの表示例 |
+|-----------------|------|-------------|
+| `Exceeds daily swap limit` | コミュニティ全体の日次上限超過 | 「本日のコミュニティ全体の回収上限に達しました」 |
+| `Exceeds daily individual swap limit` | 個人の日次上限超過 | 「本日のあなたの回収上限に達しました」 |
+| `Insufficient balance` | トークン残高不足 | 「残高が不足しています」 |
+
+---
+
+## 参照用: 既存メソッド（変更なし）
+
+| メソッド | 説明 |
+|---------|------|
+| `getTodaySwapableToPCEBalance()` | 本日のグローバル限度額（上限値そのもの） |
+| `getTodaySwapableToPCEBalanceForIndividual(address)` | 本日の個人限度額（上限値そのもの） |
+
+> これらは引き続き利用可能です。プログレスバー等で「上限値」と「残り」の両方を表示する場合に使えます。
+
+---
+
+## UI実装例
+
+### 回収画面の表示
+
+```
+本日の回収上限:     100 TCT  ← getTodaySwapableToPCEBalanceForIndividual(user)
+本日の回収済み:      30 TCT  ← 上限 − 残り
+残り回収可能量:      70 TCT  ← getRemainingSwapableToPCEBalanceForIndividual(user)
+[===========-------] 30%
+
+コミュニティ全体:
+  上限 500 TCT / 残り 420 TCT  ← getTodaySwapableToPCEBalance() / getRemainingSwapableToPCEBalance()
+```
+
+### 入力バリデーション
+
+```javascript
+const globalRemaining = await communityToken.getRemainingSwapableToPCEBalance();
+const individualRemaining = await communityToken.getRemainingSwapableToPCEBalanceForIndividual(userAddress);
+const userBalance = await communityToken.balanceOf(userAddress);
+
+const maxSwapable = min(globalRemaining, individualRemaining, userBalance);
+
+// 入力フォームの最大値に設定
+inputField.max = formatEther(maxSwapable);
+```
+
+---
+
+## 日次リセットのタイミング
+
+- UTC 0:00 を基準に日が変わります
+- 厳密には、日をまたいだ後の**最初のトランザクション実行時**にリセットされます
+- View メソッド（`getRemaining~`）は、日をまたいでいれば即座に累計0として計算します（トランザクション不要）

--- a/script/Upgrade.s.sol
+++ b/script/Upgrade.s.sol
@@ -11,7 +11,7 @@ contract Upgrade is BaseScript {
         address pceTokenAddress = 0xA4807a8C34353A5EA51aF073175950Cb6248dA7E;
         address pceCommunityTokenAddress = 0x6A73A610707C113F34D8B82498b6868e5f7FAA74;
 
-        Upgrades.upgradeProxy(pceTokenAddress, "PCETokenV10.sol:PCETokenV10", "");
-        Upgrades.upgradeBeacon(pceCommunityTokenAddress, "PCECommunityTokenV10.sol:PCECommunityTokenV10");
+        Upgrades.upgradeProxy(pceTokenAddress, "PCETokenV11.sol:PCETokenV11", "");
+        Upgrades.upgradeBeacon(pceCommunityTokenAddress, "PCECommunityTokenV11.sol:PCECommunityTokenV11");
     }
 }

--- a/script/UpgradeDEV.s.sol
+++ b/script/UpgradeDEV.s.sol
@@ -11,7 +11,7 @@ contract UpgradeDEV is BaseScript {
         address pceTokenAddress = 0x62Ef93EAa5bB3E47E0e855C323ef156c8E3D8913;
         address pceCommunityTokenAddress = 0xA9D965660dcF0fA73E709fd802e9DEF2d9b52952;
 
-        Upgrades.upgradeProxy(pceTokenAddress, "PCETokenV10.sol:PCETokenV10", "");
-        Upgrades.upgradeBeacon(pceCommunityTokenAddress, "PCECommunityTokenV10.sol:PCECommunityTokenV10");
+        Upgrades.upgradeProxy(pceTokenAddress, "PCETokenV11.sol:PCETokenV11", "");
+        Upgrades.upgradeBeacon(pceCommunityTokenAddress, "PCECommunityTokenV11.sol:PCECommunityTokenV11");
     }
 }

--- a/src/PCECommunityTokenV11.sol
+++ b/src/PCECommunityTokenV11.sol
@@ -1,0 +1,872 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import { ERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol";
+import { ERC20BurnableUpgradeable } from
+    "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC20BurnableUpgradeable.sol";
+import { Initializable } from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import { OwnableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import { ERC20PermitUpgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC20PermitUpgradeable.sol";
+import { PCETokenV11 } from "./PCETokenV11.sol";
+import { Utils } from "./lib/Utils.sol";
+import { EIP3009 } from "./lib/EIP3009.sol";
+import { EIP712 } from "./lib/EIP712.sol";
+import { TokenSetting } from "./lib/TokenSetting.sol";
+import { ExchangeAllowMethod } from "./lib/Enum.sol";
+import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
+import { VoucherSystem } from "./lib/VoucherSystem.sol";
+/// @custom:oz-upgrades-from PCECommunityTokenV10
+
+contract PCECommunityTokenV11 is
+    Initializable,
+    ERC20Upgradeable,
+    ERC20BurnableUpgradeable,
+    OwnableUpgradeable,
+    EIP3009,
+    ERC20PermitUpgradeable,
+    TokenSetting
+{
+    uint256 public constant INITIAL_FACTOR = 10 ** 18;
+    uint16 public constant BP_BASE = 10_000;
+    uint16 public constant MAX_CHARACTER_LENGTH = 10;
+
+    /*
+        keccak256(
+            "TransferFromWithAuthorization(address spender,address from,address to,
+                uint256 value,uint256 validAfter,uint256 validBefore,bytes32 nonce)"
+        )
+    */
+    bytes32 public constant TRANSFER_FROM_WITH_AUTHORIZATION_TYPEHASH =
+        0xdc2e81fe1efc0fd8f409b4ea3e0551766bc1a7f569028058d8b21a404fd81480;
+
+    /*
+        keccak256(
+            "SetInfinityApproveFlagWithAuthorization(address owner,address spender,
+                bool flag,uint256 validAfter,uint256 validBefore,bytes32 nonce)"
+        )
+    */
+    bytes32 public constant SET_INFINITY_APPROVE_FLAG_WITH_AUTHORIZATION_TYPEHASH =
+        0xae8989bee557ad51c17ff078fc59b7a54343dae31bac9bad6f6c9fe90486684e;
+
+    /*
+        keccak256(
+            "ClaimWithAuthorization(address claimer,string issuanceId,string code,
+                uint256 validAfter,uint256 validBefore,bytes32 nonce)"
+        )
+    */
+    bytes32 public constant CLAIM_WITH_AUTHORIZATION_TYPEHASH =
+        0x0b6aae1d90e3a85a25061f4c51e754a9cce2a86cf2f51fb09be1001de8fb7c0a;
+
+    address public pceAddress;
+    uint256 public initialFactor;
+    uint256 public epochTime;
+    uint256 public lastModifiedFactor;
+
+    struct AccountInfo {
+        uint256 midnightBalance;
+        uint256 firstTransactionTime;
+        uint256 lastModifiedMidnightBalanceTime;
+        uint256 mintArigatoCreationToday;
+    }
+
+    struct VoucherIssuanceInfo {
+        string issuanceId;
+        address owner;
+        string name;
+        uint256 amountPerClaim;
+        uint256 countLimitPerUser;
+        uint256 totalAmountLimit;
+        uint256 startTime;
+        uint256 endTime;
+        bytes32 merkleRoot;
+        bool isActive;
+        uint256 remainingAmount;
+        uint256 claimedAmount;
+        uint256 claimedDisplayAmount;
+        uint256 totalClaimCount;
+        string ipfsCid;  // Optional IPFS CID for additional metadata
+    }
+
+    mapping(address user => AccountInfo accountInfo) private _accountInfos;
+    mapping(address owner => mapping(address spender => bool flag)) private _infinityApproveFlags;
+
+    VoucherSystem.VoucherStorage private _voucherStorage;
+
+    // --- V11: Daily swap-to-PCE tracking ---
+    uint256 public swappedToPCEToday;
+    uint256 public swappedToPCETodayModifiedTime;
+    mapping(address => uint256) public swappedToPCETodayByAddress;
+    mapping(address => uint256) public swappedToPCETodayByAddressModifiedTime;
+
+    event PCETransfer(address indexed from, address indexed to, uint256 displayAmount, uint256 rawAmount);
+    event MintArigatoCreation(address indexed to, uint256 displayAmount, uint256 rawAmount);
+    event MetaTransactionFeeCollected(address indexed from, address indexed to, uint256 displayFee, uint256 rawFee);
+    event InfinityApproveFlagSet(address indexed owner, address indexed spender, bool flag);
+
+    function initialize(string memory name, string memory symbol, uint256 _initialFactor) public initializer {
+        __ERC20_init(name, symbol);
+        __Ownable_init(_msgSender());
+        __ERC20Permit_init(name);
+        pceAddress = _msgSender();
+        epochTime = block.timestamp;
+        lastDecreaseTime = block.timestamp;
+        initialFactor = _initialFactor;
+        lastModifiedFactor = _initialFactor;
+    }
+
+    function getCurrentFactor() public view returns (uint256) {
+        if (lastModifiedFactor == 0) {
+            return 0;
+        }
+        if (decreaseIntervalDays == 0) {
+            return lastModifiedFactor;
+        }
+        if (intervalDaysOf(lastDecreaseTime, block.timestamp, decreaseIntervalDays)) {
+            return Math.mulDiv(lastModifiedFactor, afterDecreaseBp, BP_BASE);
+        } else {
+            return lastModifiedFactor;
+        }
+    }
+
+    function updateFactorIfNeeded() public {
+        if (lastDecreaseTime == block.timestamp) {
+            return;
+        }
+
+        PCETokenV11 pceToken = PCETokenV11(pceAddress);
+        pceToken.updateFactorIfNeeded();
+
+        uint256 currentFactor = getCurrentFactor();
+        if (currentFactor != lastModifiedFactor) {
+            lastModifiedFactor = currentFactor;
+            lastDecreaseTime = block.timestamp;
+        }
+    }
+
+    function rawBalanceToDisplayBalance(uint256 rawBalance) public view returns (uint256) {
+        uint256 currentFactor = getCurrentFactor();
+        if (currentFactor < 1) {
+            currentFactor = 1;
+        }
+        return rawBalance / currentFactor;
+    }
+
+    function displayBalanceToRawBalance(uint256 displayBalance) public view returns (uint256) {
+        uint256 currentFactor = getCurrentFactor();
+        if (currentFactor < 1) {
+            currentFactor = 1;
+        }
+        return displayBalance * currentFactor;
+    }
+
+    function totalSupply() public view override returns (uint256) {
+        return rawBalanceToDisplayBalance(super.totalSupply());
+    }
+
+    function balanceOf(address account) public view override returns (uint256) {
+        return rawBalanceToDisplayBalance(super.balanceOf(account));
+    }
+
+    function _update(address from, address to, uint256 value) internal override {
+        _beforeTokenTransfer(from, to, value);
+        super._update(from, to, value);
+        _afterTokenTransfer(from, to, value);
+    }
+
+    function _beforeTokenTransfer(address from, address to, uint256 amount) internal {
+        if (midnightTotalSupplyModifiedTime == 0) {
+            midnightTotalSupply = amount;
+            midnightTotalSupplyModifiedTime = block.timestamp;
+        } else if (intervalDaysOf(midnightTotalSupplyModifiedTime, block.timestamp, 1)) {
+            midnightTotalSupply = super.totalSupply();
+            midnightTotalSupplyModifiedTime = block.timestamp;
+            // Reset arigatoCreateionMintToday, but set it to 1 instead of 0 to reduce gas consumption
+            mintArigatoCreationToday = 1;
+            mintArigatoCreationTodayForGuest = 1;
+        }
+        if (from != address(0)) {
+            _beforeTokenTransferAtAddress(from);
+        }
+        if (to != address(0)) {
+            _beforeTokenTransferAtAddress(to);
+        }
+    }
+
+    function _beforeTokenTransferAtAddress(address account) internal {
+        if (_accountInfos[account].firstTransactionTime == 0) {
+            _accountInfos[account].firstTransactionTime = block.timestamp;
+            _accountInfos[account].lastModifiedMidnightBalanceTime = block.timestamp;
+            _accountInfos[account].midnightBalance = super.balanceOf(account);
+        } else if (intervalDaysOf(_accountInfos[account].lastModifiedMidnightBalanceTime, block.timestamp, 1)) {
+            _accountInfos[account].lastModifiedMidnightBalanceTime = block.timestamp;
+            _accountInfos[account].midnightBalance = super.balanceOf(account);
+            // Reset arigatoCreateionMintToday, but set it to 1 instead of 0 to reduce gas consumption
+            _accountInfos[account].mintArigatoCreationToday = 1;
+        }
+    }
+
+    function _afterTokenTransfer(address from, address to, uint256 amount) internal {
+        emit PCETransfer(from, to, rawBalanceToDisplayBalance(amount), amount);
+    }
+
+    function _mintArigatoCreation(
+        address sender,
+        uint256 rawAmount,
+        uint256 rawBalance,
+        uint256 messageCharacters
+    )
+        internal
+    {
+        // ** Global mint limit
+        uint256 maxArigatoCreationMintToday = Math.mulDiv(midnightTotalSupply, maxIncreaseOfTotalSupplyBp, BP_BASE);
+        if (maxArigatoCreationMintToday <= 0 || maxArigatoCreationMintToday <= mintArigatoCreationToday) {
+            return;
+        }
+        uint256 remainingArigatoCreationMintToday = maxArigatoCreationMintToday - mintArigatoCreationToday;
+        uint256 remainingArigatoCreationMintTodayForGuest;
+
+        AccountInfo memory accountInfo = _accountInfos[sender];
+
+        bool isGuest = accountInfo.firstTransactionTime == accountInfo.lastModifiedMidnightBalanceTime;
+        if (isGuest) {
+            uint256 maxArigatoCreationMintTodayForGuest = Math.mulDiv(maxArigatoCreationMintToday, 1, 10);
+            if (
+                maxArigatoCreationMintTodayForGuest <= 0
+                    || maxArigatoCreationMintTodayForGuest <= mintArigatoCreationTodayForGuest
+            ) {
+                return;
+            }
+            remainingArigatoCreationMintTodayForGuest =
+                maxArigatoCreationMintTodayForGuest - mintArigatoCreationTodayForGuest;
+        }
+
+        // ** Calculation of mint amount
+        // increaseRate = (maxIncreaseRate - changeRate * abs(maxUsageRate - usageRate)) * valueOfMessageCharacter
+        uint256 usageBp = Math.mulDiv(rawAmount, BP_BASE, rawBalance);
+        uint256 absUsageBp = usageBp > maxUsageBp ? usageBp - maxUsageBp : uint256(maxUsageBp) - usageBp;
+        uint256 changeMulBp = Math.mulDiv(uint256(changeBp), absUsageBp, BP_BASE);
+        if (changeMulBp >= maxIncreaseBp) {
+            return;
+        }
+        uint256 messageLength = messageCharacters > 0 ? messageCharacters : 1;
+        uint256 messageBp =
+            messageLength > MAX_CHARACTER_LENGTH ? BP_BASE : Math.mulDiv(messageLength, BP_BASE, MAX_CHARACTER_LENGTH);
+        uint256 increaseBp = uint256(maxIncreaseBp) - Math.mulDiv(changeMulBp, messageBp, BP_BASE);
+        uint256 mintAmount = Math.mulDiv(rawAmount, increaseBp, BP_BASE);
+        if (mintAmount > remainingArigatoCreationMintToday) {
+            mintAmount = remainingArigatoCreationMintToday;
+        }
+
+        // ** Sender mint limit
+        if (!isGuest) {
+            uint256 maxArigatoCreationMintTodayForSender =
+                Math.mulDiv(maxArigatoCreationMintToday, accountInfo.midnightBalance, midnightTotalSupply);
+            if (maxArigatoCreationMintTodayForSender <= 0) {
+                return;
+            }
+            if (mintAmount > maxArigatoCreationMintTodayForSender) {
+                mintAmount = maxArigatoCreationMintTodayForSender;
+            }
+        } else {
+            // Guest can mint only 1% of maxArigatoCreationMintToday
+            if (mintAmount > remainingArigatoCreationMintTodayForGuest) {
+                mintAmount = remainingArigatoCreationMintTodayForGuest;
+            }
+            uint256 maxArigatoCreationMintTodayForGuestSender = Math.mulDiv(maxArigatoCreationMintToday, 1, 100);
+            if (maxArigatoCreationMintTodayForGuestSender <= 0) {
+                return;
+            }
+            if (mintAmount > maxArigatoCreationMintTodayForGuestSender) {
+                mintAmount = maxArigatoCreationMintTodayForGuestSender;
+            }
+        }
+
+        // ** Execute mint
+        _mint(sender, mintAmount);
+        unchecked {
+            accountInfo.mintArigatoCreationToday += mintAmount;
+            mintArigatoCreationToday += mintAmount;
+            if (isGuest) {
+                mintArigatoCreationTodayForGuest += mintAmount;
+            }
+        }
+        emit MintArigatoCreation(sender, rawBalanceToDisplayBalance(mintAmount), mintAmount);
+    }
+
+    function transfer(address receiver, uint256 displayAmount) public override returns (bool) {
+        updateFactorIfNeeded();
+        uint256 rawBalance = super.balanceOf(_msgSender());
+        uint256 rawAmount = displayBalanceToRawBalance(displayAmount);
+        bool ret = super.transfer(receiver, rawAmount);
+
+        _mintArigatoCreation(_msgSender(), rawAmount, rawBalance, 1);
+
+        return ret;
+    }
+
+    function _spendAllowance(address owner, address spender, uint256 value) internal virtual override {
+        // Check infinity approve flag first
+        if (_infinityApproveFlags[owner][spender]) {
+            return; // Skip allowance check if infinity approve flag is set
+        }
+
+        uint256 currentAllowance = super.allowance(owner, spender);
+        if (currentAllowance != type(uint256).max) {
+            if (currentAllowance < value) {
+                revert ERC20InsufficientAllowance(spender, currentAllowance, value);
+            }
+            unchecked {
+                _approve(owner, spender, currentAllowance - value, false);
+            }
+        }
+    }
+
+    function transferFrom(address sender, address receiver, uint256 displayBalance) public override returns (bool) {
+        updateFactorIfNeeded();
+        uint256 rawBalance = super.balanceOf(sender);
+        uint256 rawAmount = displayBalanceToRawBalance(displayBalance);
+        bool ret = super.transferFrom(sender, receiver, rawAmount);
+
+        _mintArigatoCreation(sender, rawAmount, rawBalance, 1);
+
+        return ret;
+    }
+
+    function approve(address spender, uint256 displayBalance) public override returns (bool) {
+        updateFactorIfNeeded();
+        uint256 rawBalance = displayBalanceToRawBalance(displayBalance);
+        return super.approve(spender, rawBalance);
+    }
+
+    function allowance(address owner, address spender) public view override returns (uint256) {
+        return rawBalanceToDisplayBalance(super.allowance(owner, spender));
+    }
+
+    function mint(address to, uint256 displayBalance) external {
+        require(_msgSender() == owner() || _msgSender() == pceAddress, "Only owner or PCE token");
+        updateFactorIfNeeded();
+        _mint(to, displayBalanceToRawBalance(displayBalance));
+    }
+
+    function burn(uint256 displayBalance) public override {
+        updateFactorIfNeeded();
+        super.burn(displayBalanceToRawBalance(displayBalance));
+    }
+
+    function burnFrom(address account, uint256 displayBalance) public override {
+        updateFactorIfNeeded();
+        super.burnFrom(account, displayBalanceToRawBalance(displayBalance));
+    }
+
+    function burnByPCEToken(address account, uint256 displayBalance) external {
+        require(_msgSender() == pceAddress, "Only PCE token");
+        updateFactorIfNeeded();
+        _burn(account, displayBalanceToRawBalance(displayBalance));
+    }
+
+    function intervalDaysOf(uint256 start, uint256 end, uint256 intervalDays) public pure returns (bool) {
+        if (start >= end) {
+            return false;
+        }
+        uint256 startDay = start / 1 days;
+        uint256 endDay = end / 1 days;
+        if (startDay == endDay) {
+            return false;
+        }
+        return (endDay - startDay) >= intervalDays;
+    }
+
+    function _isAllowExchange(bool isIncome, address tokenAddress) private view returns (bool) {
+        ExchangeAllowMethod allowMethod = isIncome ? incomeExchangeAllowMethod : outgoExchangeAllowMethod;
+        address[] memory targetTokens = isIncome ? incomeTargetTokens : outgoTargetTokens;
+        if (allowMethod == ExchangeAllowMethod.None) {
+            return false;
+        } else if (allowMethod == ExchangeAllowMethod.All) {
+            return true;
+        } else if (allowMethod == ExchangeAllowMethod.Include) {
+            for (uint256 i = 0; i < targetTokens.length;) {
+                if (targetTokens[i] == tokenAddress) {
+                    return true;
+                }
+                unchecked {
+                    i++;
+                }
+            }
+            return false;
+        } else if (allowMethod == ExchangeAllowMethod.Exclude) {
+            for (uint256 i = 0; i < targetTokens.length;) {
+                if (targetTokens[i] == tokenAddress) {
+                    return false;
+                }
+                unchecked {
+                    i++;
+                }
+            }
+            return true;
+        } else {
+            revert("Invalid exchangeAllowMethod");
+        }
+    }
+
+    function isAllowOutgoExchange(address tokenAddress) public view returns (bool) {
+        return _isAllowExchange(false, tokenAddress);
+    }
+
+    function isAllowIncomeExchange(address tokenAddress) public view returns (bool) {
+        return _isAllowExchange(true, tokenAddress);
+    }
+
+    function swapTokens(address toTokenAddress, uint256 amountToSwap) public {
+        address sender = _msgSender();
+        updateFactorIfNeeded();
+        PCETokenV11 pceToken = PCETokenV11(pceAddress);
+        pceToken.updateFactorIfNeeded();
+
+        Utils.LocalToken memory fromToken = pceToken.getLocalToken(address(this));
+        require(fromToken.isExists, "From token not found");
+
+        Utils.LocalToken memory toToken = pceToken.getLocalToken(toTokenAddress);
+        require(toToken.isExists, "Target token not found");
+
+        PCECommunityTokenV11 to = PCECommunityTokenV11(toTokenAddress);
+        to.updateFactorIfNeeded();
+
+        require(balanceOf(sender) >= amountToSwap, "Insufficient balance");
+        require(isAllowOutgoExchange(toTokenAddress), "Outgo exchange not allowed");
+        require(to.isAllowIncomeExchange(address(this)), "Income exchange not allowed");
+
+        uint256 targetTokenAmount = Math.mulDiv(
+            Math.mulDiv(
+                Math.mulDiv(amountToSwap, 10 ** 18, fromToken.exchangeRate),
+                pceToken.getCurrentFactor(),
+                getCurrentFactor()
+            ),
+            Math.mulDiv(toToken.exchangeRate, to.getCurrentFactor(), INITIAL_FACTOR),
+            pceToken.getCurrentFactor()
+        );
+
+        require(targetTokenAmount > 0, "Invalid amount to swap");
+
+        super._burn(sender, displayBalanceToRawBalance(amountToSwap));
+        to.mint(sender, targetTokenAmount);
+    }
+
+    function getMetaTransactionFee() public view returns (uint256) {
+        PCETokenV11 pceToken = PCETokenV11(pceAddress);
+        uint256 pceTokenFee = pceToken.getMetaTransactionFee();
+        uint256 rate = pceToken.getSwapRate(address(this));
+        return Math.mulDiv(pceTokenFee, rate, 2**96);
+    }
+
+    function getMetaTransactionFeeWithBaseFee(uint256 _baseFee) public view returns (uint256) {
+        PCETokenV11 pceToken = PCETokenV11(pceAddress);
+        uint256 pceTokenFee = pceToken.getMetaTransactionFeeWithBaseFee(_baseFee);
+        uint256 rate = pceToken.getSwapRate(address(this));
+        return Math.mulDiv(pceTokenFee, rate, 2**96);
+    }
+
+    function transferWithAuthorization(
+        address from, address to, uint256 displayAmount, uint256 validAfter, uint256 validBefore, bytes32 nonce, uint8 v, bytes32 r, bytes32 s
+    )
+        public
+        override
+    {
+        updateFactorIfNeeded();
+        uint256 rawBalance = super.balanceOf(from);
+        uint256 rawAmount = displayBalanceToRawBalance(displayAmount);
+        uint256 displayFee = getMetaTransactionFee();
+        uint256 rawFee = displayBalanceToRawBalance(displayFee);
+        _transferWithAuthorization(from, to, displayAmount, validAfter, validBefore, nonce, v, r, s, rawAmount);
+
+        super._transfer(from, _msgSender(), rawFee);
+
+        emit MetaTransactionFeeCollected(from, _msgSender(), displayFee, rawFee);
+
+        _mintArigatoCreation(from, rawAmount, rawBalance, 1);
+    }
+
+    function transferFromWithAuthorization(
+        address spender, address from, address to, uint256 displayAmount, uint256 validAfter, uint256 validBefore, bytes32 nonce, uint8 v, bytes32 r, bytes32 s
+    )
+        public
+    {
+        updateFactorIfNeeded();
+        uint256 rawBalance = super.balanceOf(from);
+        uint256 rawAmount = displayBalanceToRawBalance(displayAmount);
+        uint256 displayFee = getMetaTransactionFee();
+        uint256 rawFee = displayBalanceToRawBalance(displayFee);
+
+        require(block.timestamp > validAfter, "Not yet valid");
+        require(block.timestamp < validBefore, "Authorization expired");
+        require(!_authorizationStates[spender][nonce], "Authorization used");
+        require(rawBalance >= (rawAmount + rawFee), "Insufficient balance");
+        require(_infinityApproveFlags[from][spender] || super.allowance(from, spender) >= rawAmount, "Insufficient allowance");
+
+        bytes memory data = abi.encode(
+            TRANSFER_FROM_WITH_AUTHORIZATION_TYPEHASH,
+            spender,
+            from,
+            to,
+            displayAmount,
+            validAfter,
+            validBefore,
+            nonce
+        );
+        bytes32 digest = keccak256(abi.encodePacked(
+            "\x19\x01",
+            this.DOMAIN_SEPARATOR(),
+            keccak256(data)
+        ));
+
+        require(
+            ecrecover(digest, v, r, s) == spender,
+            "Invalid signature"
+        );
+
+        _authorizationStates[spender][nonce] = true;
+        emit AuthorizationUsed(spender, nonce);
+
+        _spendAllowance(from, spender, rawAmount);
+        super._transfer(from, to, rawAmount);
+        super._transfer(from, _msgSender(), rawFee);
+
+        emit MetaTransactionFeeCollected(from, _msgSender(), displayFee, rawFee);
+        _mintArigatoCreation(from, rawAmount, rawBalance, 1);
+    }
+
+    /*
+        @notice Returns the total balance that can be swapped to PCE today
+        The balance is 0.01 times the total supply at UTC 0
+    */
+    function getTodaySwapableToPCEBalance() public view returns (uint256) {
+        PCETokenV11 pceToken = PCETokenV11(pceAddress);
+
+        return rawBalanceToDisplayBalance(Math.mulDiv(midnightTotalSupply, pceToken.swapableToPCERate(), BP_BASE));
+    }
+
+    /*
+        @notice Returns the total balance that can be swapped to PCE today for the individual
+        The balance is 0.01 times the balance of the individual at UTC 0
+    */
+    function getTodaySwapableToPCEBalanceForIndividual(address checkAddress) public view returns (uint256) {
+        PCETokenV11 pceToken = PCETokenV11(pceAddress);
+
+        AccountInfo memory accountInfo = _accountInfos[checkAddress];
+        uint256 individualRate = pceToken.swapableToPCEIndividualRate();
+        uint256 rawAmount = Math.mulDiv(accountInfo.midnightBalance, individualRate, BP_BASE);
+
+        return rawBalanceToDisplayBalance(rawAmount);
+    }
+
+    // --- V11: Record daily swap-to-PCE usage ---
+    function recordSwapToPCE(address account, uint256 displayAmount) external {
+        require(_msgSender() == pceAddress, "Only PCE token");
+        // Global daily reset
+        if (intervalDaysOf(swappedToPCETodayModifiedTime, block.timestamp, 1)) {
+            swappedToPCEToday = 0;
+            swappedToPCETodayModifiedTime = block.timestamp;
+        }
+        if (swappedToPCETodayModifiedTime == 0) {
+            swappedToPCETodayModifiedTime = block.timestamp;
+        }
+        // Individual daily reset
+        if (intervalDaysOf(swappedToPCETodayByAddressModifiedTime[account], block.timestamp, 1)) {
+            swappedToPCETodayByAddress[account] = 0;
+            swappedToPCETodayByAddressModifiedTime[account] = block.timestamp;
+        }
+        if (swappedToPCETodayByAddressModifiedTime[account] == 0) {
+            swappedToPCETodayByAddressModifiedTime[account] = block.timestamp;
+        }
+        swappedToPCEToday += displayAmount;
+        swappedToPCETodayByAddress[account] += displayAmount;
+    }
+
+    // --- V11: Remaining swapable balance (global) ---
+    function getRemainingSwapableToPCEBalance() public view returns (uint256) {
+        uint256 limit = getTodaySwapableToPCEBalance();
+        uint256 used = swappedToPCEToday;
+        if (swappedToPCETodayModifiedTime == 0 || intervalDaysOf(swappedToPCETodayModifiedTime, block.timestamp, 1)) {
+            used = 0;
+        }
+        return limit > used ? limit - used : 0;
+    }
+
+    // --- V11: Remaining swapable balance (individual) ---
+    function getRemainingSwapableToPCEBalanceForIndividual(address account) public view returns (uint256) {
+        uint256 limit = getTodaySwapableToPCEBalanceForIndividual(account);
+        uint256 used = swappedToPCETodayByAddress[account];
+        if (swappedToPCETodayByAddressModifiedTime[account] == 0 || intervalDaysOf(swappedToPCETodayByAddressModifiedTime[account], block.timestamp, 1)) {
+            used = 0;
+        }
+        return limit > used ? limit - used : 0;
+    }
+
+    function setInfinityApproveFlag(address spender, bool flag) public {
+        _infinityApproveFlags[_msgSender()][spender] = flag;
+        emit InfinityApproveFlagSet(_msgSender(), spender, flag);
+    }
+
+    function getInfinityApproveFlag(address owner, address spender) public view returns (bool) {
+        return _infinityApproveFlags[owner][spender];
+    }
+
+    function setInfinityApproveFlagWithAuthorization(
+        address owner, address spender, bool flag, uint256 validAfter, uint256 validBefore, bytes32 nonce, uint8 v, bytes32 r, bytes32 s
+    )
+        public
+    {
+        updateFactorIfNeeded();
+        uint256 displayFee = getMetaTransactionFee();
+        uint256 rawFee = displayBalanceToRawBalance(displayFee);
+
+        require(block.timestamp > validAfter, "Not yet valid");
+        require(block.timestamp < validBefore, "Authorization expired");
+        require(!_authorizationStates[owner][nonce], "Authorization used");
+        require(super.balanceOf(owner) >= (rawFee), "Insufficient balance");
+
+        bytes memory data = abi.encode(
+            SET_INFINITY_APPROVE_FLAG_WITH_AUTHORIZATION_TYPEHASH,
+            owner,
+            spender,
+            flag,
+            validAfter,
+            validBefore,
+            nonce
+        );
+        bytes32 digest = keccak256(abi.encodePacked(
+            "\x19\x01",
+            this.DOMAIN_SEPARATOR(),
+            keccak256(data)
+        ));
+
+        require(
+            ecrecover(digest, v, r, s) == owner,
+            "Invalid signature"
+        );
+
+        _authorizationStates[owner][nonce] = true;
+        emit AuthorizationUsed(owner, nonce);
+
+        _infinityApproveFlags[owner][spender] = flag;
+        emit InfinityApproveFlagSet(owner, spender, flag);
+
+        // Collect meta transaction fee from owner
+        super._transfer(owner, _msgSender(), rawFee);
+        emit MetaTransactionFeeCollected(owner, _msgSender(), displayFee, rawFee);
+    }
+
+    // Voucher functions
+    function registerVoucherIssuance(
+        string memory issuanceId,
+        string memory _name,
+        uint256 _amountPerClaim,
+        uint256 _countLimitPerUser,
+        uint256 _totalAmountLimit,
+        uint256 _initialFunds,
+        uint256 _startTime,
+        uint256 _endTime,
+        bytes32 _merkleRoot,
+        string memory _ipfsCid
+    )
+        external
+    {
+        uint256 initialFundsRawAmount = displayBalanceToRawBalance(_initialFunds);
+        require(super.balanceOf(_msgSender()) >= initialFundsRawAmount, "Insufficient balance");
+
+        VoucherSystem.registerIssuance(
+            _voucherStorage,
+            issuanceId,
+            _name,
+            _amountPerClaim,
+            _countLimitPerUser,
+            _totalAmountLimit,
+            initialFundsRawAmount,
+            _startTime,
+            _endTime,
+            _merkleRoot,
+            _msgSender(),
+            _ipfsCid
+        );
+
+        // Lock tokens from issuer
+        super._transfer(_msgSender(), address(this), initialFundsRawAmount);
+    }
+
+    function claimVoucher(string memory issuanceId, string memory code, bytes32[] calldata proof) external {
+        VoucherSystem.VoucherIssuance memory issuance = VoucherSystem.getIssuance(_voucherStorage, issuanceId);
+        uint256 rawClaimAmount = displayBalanceToRawBalance(issuance.amountPerClaim);
+
+        VoucherSystem.claim(_voucherStorage, issuanceId, code, proof, _msgSender(), rawClaimAmount);
+
+        // Transfer tokens from contract to claimer
+        super._transfer(address(this), _msgSender(), rawClaimAmount);
+    }
+
+    function claimVoucherWithAuthorization(
+        address claimer,
+        string memory issuanceId,
+        string memory code,
+        bytes32[] calldata proof,
+        uint256 validAfter,
+        uint256 validBefore,
+        bytes32 nonce,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    )
+        external
+    {
+        updateFactorIfNeeded();
+        uint256 displayFee = getMetaTransactionFee();
+        uint256 rawFee = displayBalanceToRawBalance(displayFee);
+
+        require(block.timestamp > validAfter, "Not yet valid");
+        require(block.timestamp < validBefore, "Authorization expired");
+        require(!_authorizationStates[claimer][nonce], "Authorization used");
+
+        bytes memory data = abi.encode(
+            CLAIM_WITH_AUTHORIZATION_TYPEHASH,
+            claimer,
+            keccak256(bytes(issuanceId)),
+            keccak256(bytes(code)),
+            validAfter,
+            validBefore,
+            nonce
+        );
+        bytes32 digest = keccak256(abi.encodePacked("\x19\x01", this.DOMAIN_SEPARATOR(), keccak256(data)));
+
+        require(ecrecover(digest, v, r, s) == claimer, "Invalid signature");
+
+        _authorizationStates[claimer][nonce] = true;
+        emit AuthorizationUsed(claimer, nonce);
+
+        // Get claim amount and convert to raw balance
+        VoucherSystem.VoucherIssuance memory issuance = VoucherSystem.getIssuance(_voucherStorage, issuanceId);
+        uint256 rawClaimAmount = displayBalanceToRawBalance(issuance.amountPerClaim);
+
+        // Check if claim amount is greater than meta transaction fee
+        require(rawClaimAmount > rawFee, "Claim amount must be greater than fee");
+
+        // Claim from voucher
+        VoucherSystem.claim(_voucherStorage, issuanceId, code, proof, claimer, rawClaimAmount);
+
+        // Calculate amount after deducting fee
+        uint256 amountAfterFee = rawClaimAmount - rawFee;
+
+        // Transfer amount after fee to claimer
+        super._transfer(address(this), claimer, amountAfterFee);
+
+        // Collect meta transaction fee from claimed amount
+        super._transfer(address(this), _msgSender(), rawFee);
+        emit MetaTransactionFeeCollected(claimer, _msgSender(), displayFee, rawFee);
+    }
+
+    function getVoucherIssuanceInfo(string memory issuanceId)
+        external
+        view
+        returns (VoucherIssuanceInfo memory)
+    {
+        VoucherSystem.VoucherIssuance memory issuance = VoucherSystem.getIssuance(_voucherStorage, issuanceId);
+        (uint256 remainingRawAmount, uint256 claimedRawAmount, uint256 claimedDisplayAmount, uint256 totalClaimCount) =
+            VoucherSystem.getFundsInfo(_voucherStorage, issuanceId);
+
+        return VoucherIssuanceInfo({
+            issuanceId: issuance.issuanceId,
+            owner: issuance.owner,
+            name: issuance.name,
+            amountPerClaim: issuance.amountPerClaim,
+            countLimitPerUser: issuance.countLimitPerUser,
+            totalAmountLimit: issuance.totalAmountLimit,
+            startTime: issuance.startTime,
+            endTime: issuance.endTime,
+            merkleRoot: issuance.merkleRoot,
+            isActive: issuance.isActive,
+            remainingAmount: rawBalanceToDisplayBalance(remainingRawAmount),
+            claimedAmount: rawBalanceToDisplayBalance(claimedRawAmount),
+            claimedDisplayAmount: claimedDisplayAmount,
+            totalClaimCount: totalClaimCount,
+            ipfsCid: issuance.ipfsCid
+        });
+    }
+
+    function getVoucherIssuanceIds() external view returns (string[] memory) {
+        return VoucherSystem.getIssuanceIds(_voucherStorage);
+    }
+
+    function canClaimVoucher(
+        string memory issuanceId,
+        string memory code,
+        bytes32[] calldata proof,
+        address claimer
+    )
+        external
+        view
+        returns (bool, uint8)
+    {
+        VoucherSystem.VoucherIssuance memory issuance = VoucherSystem.getIssuance(_voucherStorage, issuanceId);
+        uint256 claimRawAmount = displayBalanceToRawBalance(issuance.amountPerClaim);
+        return VoucherSystem.canClaim(_voucherStorage, issuanceId, code, proof, claimer, claimRawAmount);
+    }
+
+    function addVoucherFunds(string memory issuanceId, uint256 _amount) external {
+        uint256 rawAmount = displayBalanceToRawBalance(_amount);
+        require(super.balanceOf(_msgSender()) >= rawAmount, "Insufficient balance");
+
+        VoucherSystem.addFunds(_voucherStorage, issuanceId, rawAmount, _msgSender());
+
+        // Transfer tokens from sender to contract
+        super._transfer(_msgSender(), address(this), rawAmount);
+    }
+
+    function withdrawVoucherFunds(string memory issuanceId, uint256 _amount) external {
+        uint256 rawAmount = displayBalanceToRawBalance(_amount);
+
+        uint256 withdrawnRawAmount = VoucherSystem.withdrawFunds(_voucherStorage, issuanceId, rawAmount, _msgSender());
+
+        // Transfer tokens from contract to sender
+        super._transfer(address(this), _msgSender(), withdrawnRawAmount);
+    }
+
+    function terminateVoucherIssuance(string memory issuanceId) external {
+        uint256 remainingRawAmount = VoucherSystem.terminateIssuance(_voucherStorage, issuanceId, _msgSender());
+
+        // Transfer remaining tokens from contract to sender
+        if (remainingRawAmount > 0) {
+            super._transfer(address(this), _msgSender(), remainingRawAmount);
+        }
+    }
+
+    function setTokenSettings(
+        uint256 _decreaseIntervalDays,
+        uint16 _afterDecreaseBp,
+        uint16 _maxIncreaseOfTotalSupplyBp,
+        uint16 _maxIncreaseBp,
+        uint16 _maxUsageBp,
+        uint16 _changeBp,
+        ExchangeAllowMethod _incomeExchangeAllowMethod,
+        ExchangeAllowMethod _outgoExchangeAllowMethod,
+        address[] calldata _incomeTargetTokens,
+        address[] calldata _outgoTargetTokens
+    )
+        public
+        override
+        onlyOwner
+    {
+        super.setTokenSettings(
+            _decreaseIntervalDays,
+            _afterDecreaseBp,
+            _maxIncreaseOfTotalSupplyBp,
+            _maxIncreaseBp,
+            _maxUsageBp,
+            _changeBp,
+            _incomeExchangeAllowMethod,
+            _outgoExchangeAllowMethod,
+            _incomeTargetTokens,
+            _outgoTargetTokens
+        );
+    }
+
+    function version() public pure returns (string memory) {
+        return "1.0.11";
+    }
+}

--- a/src/PCETokenV11.sol
+++ b/src/PCETokenV11.sol
@@ -1,0 +1,367 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import { BeaconProxy } from "@openzeppelin/contracts/proxy/beacon/BeaconProxy.sol";
+import { UUPSUpgradeable } from "@openzeppelin/contracts/proxy/utils/UUPSUpgradeable.sol";
+import { ERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol";
+import { OwnableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import { Initializable } from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import { ERC20BurnableUpgradeable } from
+    "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC20BurnableUpgradeable.sol";
+import { Clones } from "@openzeppelin/contracts/proxy/Clones.sol";
+import { PCECommunityTokenV11 } from "./PCECommunityTokenV11.sol";
+import { Utils } from "./lib/Utils.sol";
+import { ExchangeAllowMethod } from "./lib/Enum.sol";
+import { NativeMetaTransaction } from "./lib/polygon/NativeMetaTransaction.sol";
+import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
+/// @custom:oz-upgrades-from PCETokenV10
+
+contract PCETokenV11 is
+    UUPSUpgradeable,
+    Initializable,
+    ERC20Upgradeable,
+    OwnableUpgradeable,
+    ERC20BurnableUpgradeable,
+    NativeMetaTransaction
+{
+    uint160 public nativeTokenToPceTokenRate;
+    uint256 public metaTransactionGas;
+    uint256 public metaTransactionPriorityFee;
+
+    // Daily swap rate from community token to PCE in basis points
+    uint256 public swapableToPCERate;
+    // Individual daily swap limit from community token to PCE in basis points
+    uint256 public swapableToPCEIndividualRate;
+
+    address private _communityTokenAddress;
+    address[] public tokens;
+    mapping(address deployedAddress => Utils.LocalToken localToken) public localTokens;
+
+    address public polygonChainManager;
+
+    event TokenCreated(
+        address indexed tokenAddress, address indexed creator, uint256 pcetokenAmount, uint256 newTokenAmount
+    );
+    event TokensSwappedToLocalToken(
+        address indexed from, address indexed toToken, uint256 pceTokenAmount, uint256 targetTokenAmount
+    );
+    event TokensSwappedFromLocalToken(
+        address indexed to, address indexed fromToken, uint256 targetTokenAmount, uint256 pceTokenAmount
+    );
+
+    uint256 public constant INITIAL_FACTOR = 10 ** 18;
+    // 998/1000 = 0.998 (represents a 0.2% decrease)
+    uint256 public constant DECREASE_RATE = 998 * (10 ** 18);
+    uint256 public constant DECREASE_RATE_BASE = 1000 * (10 ** 18);
+
+    uint256 public epochTime;
+    uint256 public lastDecreaseTime;
+    uint256 public lastModifiedFactor;
+
+    function initialize() public initializer {
+        __ERC20_init("PCE Token", "PCE");
+        __Ownable_init(_msgSender());
+        __ERC20Burnable_init();
+        _initializeEIP712("PCE Token");
+        epochTime = block.timestamp;
+        lastDecreaseTime = block.timestamp;
+        lastModifiedFactor = INITIAL_FACTOR;
+    }
+
+    function getLocalToken(address communityToken) public view returns (Utils.LocalToken memory) {
+        return localTokens[communityToken];
+    }
+
+    function getCurrentFactor() public view returns (uint256) {
+        if (lastModifiedFactor == 0) {
+            return 0;
+        }
+        if (hasDecreaseTimeWithin(lastDecreaseTime, block.timestamp)) {
+            return Math.mulDiv(lastModifiedFactor, DECREASE_RATE, DECREASE_RATE_BASE);
+        } else {
+            return lastModifiedFactor;
+        }
+    }
+
+    function updateFactorIfNeeded() public {
+        if (lastDecreaseTime == block.timestamp) {
+            return;
+        }
+
+        uint256 currentFactor = getCurrentFactor();
+        if (currentFactor != lastModifiedFactor) {
+            lastModifiedFactor = currentFactor;
+            lastDecreaseTime = block.timestamp;
+        }
+    }
+
+    function transfer(address receiver, uint256 balance) public override returns (bool) {
+        updateFactorIfNeeded();
+        return super.transfer(receiver, balance);
+    }
+
+    function transferFrom(address sender, address receiver, uint256 balance) public override returns (bool) {
+        updateFactorIfNeeded();
+        return super.transferFrom(sender, receiver, balance);
+    }
+
+    function approve(address spender, uint256 balance) public override returns (bool) {
+        updateFactorIfNeeded();
+        return super.approve(spender, balance);
+    }
+
+    function mint(address to, uint256 balance) external onlyOwner {
+        updateFactorIfNeeded();
+        _mint(to, balance);
+    }
+
+    function getTokens() public view returns (address[] memory) {
+        return tokens;
+    }
+
+    function setCommunityTokenAddress(address communityTokenAddress) external onlyOwner {
+        _communityTokenAddress = communityTokenAddress;
+    }
+
+    function createToken(
+        string memory name,
+        string memory symbol,
+        uint256 amountToExchange,
+        uint256 dilutionFactor,
+        uint256 decreaseIntervalDays,
+        uint16 afterDecreaseBp,
+        uint16 maxIncreaseOfTotalSupplyBp,
+        uint16 maxIncreaseBp,
+        uint16 maxUsageBp,
+        uint16 changeBp,
+        ExchangeAllowMethod incomeExchangeAllowMethod,
+        ExchangeAllowMethod outgoExchangeAllowMethod,
+        address[] calldata incomeTargetTokens,
+        address[] calldata outgoTargetTokens
+    )
+        public
+    {
+        require(amountToExchange > 0, "Amount must be > 0");
+        require(balanceOf(_msgSender()) >= amountToExchange, "Insufficient PCEToken bal.");
+        require(dilutionFactor >= 10 ** 17 && dilutionFactor <= 10 ** 21, "Dilution factor 0.1-1000");
+        require(afterDecreaseBp <= 10_000, "After decrease bp <= 10000");
+
+        updateFactorIfNeeded();
+
+        BeaconProxy proxy = new BeaconProxy(
+            _communityTokenAddress,
+            abi.encodeWithSelector(
+                PCECommunityTokenV11(address(0)).initialize.selector,
+                name,
+                symbol,
+                lastModifiedFactor
+            )
+        );
+        address newTokenAddress = address(proxy);
+        PCECommunityTokenV11 newToken = PCECommunityTokenV11(newTokenAddress);
+        newToken.setTokenSettings(
+            decreaseIntervalDays,
+            afterDecreaseBp,
+            maxIncreaseOfTotalSupplyBp,
+            maxIncreaseBp,
+            maxUsageBp,
+            changeBp,
+            incomeExchangeAllowMethod,
+            outgoExchangeAllowMethod,
+            incomeTargetTokens,
+            outgoTargetTokens
+        );
+
+        uint256 newTokenAmount = (amountToExchange * dilutionFactor) / INITIAL_FACTOR;
+        _transfer(_msgSender(), address(this), amountToExchange);
+        newToken.mint(_msgSender(), newTokenAmount);
+
+        localTokens[newTokenAddress] = Utils.LocalToken(true, dilutionFactor, amountToExchange);
+        tokens.push(newTokenAddress);
+
+        newToken.transferOwnership(_msgSender());
+
+        emit TokenCreated(newTokenAddress, _msgSender(), amountToExchange, newTokenAmount);
+    }
+
+    function getDepositedPCETokens(address communityToken) public view returns (uint256) {
+        require(localTokens[communityToken].isExists, "Target token not found");
+
+        return localTokens[communityToken].depositedPCEToken;
+    }
+
+    function getExchangeRate(address communityToken) public view returns (uint256) {
+        require(localTokens[communityToken].isExists, "Target token not found");
+
+        return localTokens[communityToken].exchangeRate;
+    }
+
+    function getSwapRate(address toToken) public view returns (uint256) {
+        require(localTokens[toToken].isExists, "Target token not found");
+
+        PCECommunityTokenV11 target = PCECommunityTokenV11(toToken);
+
+        return (((localTokens[toToken].exchangeRate << 96) / INITIAL_FACTOR) * target.getCurrentFactor())
+            / getCurrentFactor();
+    }
+
+    function getSwapRateBetweenTokens(address fromToken, address toToken) public view returns (uint256) {
+        require(localTokens[fromToken].isExists, "From token not found");
+        require(localTokens[toToken].isExists, "Target token not found");
+
+        PCECommunityTokenV11 fromTarget = PCECommunityTokenV11(fromToken);
+        PCECommunityTokenV11 toTarget = PCECommunityTokenV11(toToken);
+
+        uint256 exchangeRateRatio = Math.mulDiv(
+            localTokens[toToken].exchangeRate,
+            INITIAL_FACTOR,
+            localTokens[fromToken].exchangeRate
+        );
+
+        uint256 currentFactorRatio = Math.mulDiv(
+            toTarget.getCurrentFactor(),
+            INITIAL_FACTOR,
+            fromTarget.getCurrentFactor()
+        );
+
+        uint256 result = Math.mulDiv(exchangeRateRatio, currentFactorRatio, INITIAL_FACTOR);
+        return result;
+    }
+
+    function swapToLocalToken(address toToken, uint256 amountToSwap) public {
+        updateFactorIfNeeded();
+        require(localTokens[toToken].isExists, "Target token not found");
+        require(balanceOf(_msgSender()) >= amountToSwap, "Not enough PCEToken balance");
+
+        PCECommunityTokenV11 target = PCECommunityTokenV11(toToken);
+        target.updateFactorIfNeeded();
+
+        uint256 targetTokenAmount = Math.mulDiv(
+            Math.mulDiv(amountToSwap, localTokens[toToken].exchangeRate, INITIAL_FACTOR),
+            target.getCurrentFactor(),
+            lastModifiedFactor
+        );
+        require(targetTokenAmount > 0, "Invalid amount to swap");
+
+        _transfer(_msgSender(), address(this), amountToSwap);
+        target.mint(_msgSender(), targetTokenAmount);
+
+        localTokens[toToken].depositedPCEToken = localTokens[toToken].depositedPCEToken + amountToSwap;
+
+        emit TokensSwappedToLocalToken(_msgSender(), toToken, amountToSwap, targetTokenAmount);
+    }
+
+    function swapFromLocalToken(address fromToken, uint256 amountToSwap) public {
+        updateFactorIfNeeded();
+        require(localTokens[fromToken].isExists, "Target token not found");
+
+        PCECommunityTokenV11 target = PCECommunityTokenV11(fromToken);
+        target.updateFactorIfNeeded();
+
+        require(target.balanceOf(_msgSender()) >= amountToSwap, "Insufficient balance");
+
+        uint256 pcetokenAmount = Math.mulDiv(
+            Math.mulDiv(amountToSwap, INITIAL_FACTOR, localTokens[fromToken].exchangeRate),
+            lastModifiedFactor,
+            target.getCurrentFactor()
+        );
+        require(pcetokenAmount > 0, "Target token deposit low");
+
+        require(target.getRemainingSwapableToPCEBalance() >= amountToSwap, "Exceeds daily swap limit");
+        require(target.getRemainingSwapableToPCEBalanceForIndividual(_msgSender()) >= amountToSwap, "Exceeds daily individual swap limit");
+
+        target.burnByPCEToken(_msgSender(), amountToSwap);
+        target.recordSwapToPCE(_msgSender(), amountToSwap);
+        _transfer(address(this), _msgSender(), pcetokenAmount);
+
+        localTokens[fromToken].depositedPCEToken = localTokens[fromToken].depositedPCEToken - pcetokenAmount;
+
+        emit TokensSwappedFromLocalToken(_msgSender(), fromToken, amountToSwap, pcetokenAmount);
+    }
+
+    function getNativeTokenToPceTokenRate() public view returns (uint256) {
+        return nativeTokenToPceTokenRate;
+    }
+
+    function setNativeTokenToPceTokenRate(uint160 _nativeTokenToPceTokenRate) public onlyOwner {
+        nativeTokenToPceTokenRate = _nativeTokenToPceTokenRate;
+    }
+
+    function setMetaTransactionGas(uint256 _metaTransactionGas) public onlyOwner {
+        metaTransactionGas = _metaTransactionGas;
+    }
+
+    function setMetaTransactionPriorityFee(uint256 _metaTransactionPriorityFee) public onlyOwner {
+        metaTransactionPriorityFee = _metaTransactionPriorityFee;
+    }
+
+    function getBlockBaseFee() public view returns (uint256) {
+        return block.basefee;
+    }
+
+    function getMetaTransactionFee() public view returns (uint256) {
+        uint256 nativeTokenFee = metaTransactionGas * (block.basefee + metaTransactionPriorityFee);
+        return Math.mulDiv(nativeTokenFee, getNativeTokenToPceTokenRate(), 2**96);
+    }
+
+    function getMetaTransactionFeeWithBaseFee(uint256 _baseFee) public view returns (uint256) {
+        uint256 nativeTokenFee = metaTransactionGas * (_baseFee + metaTransactionPriorityFee);
+        return Math.mulDiv(nativeTokenFee, getNativeTokenToPceTokenRate(), 2**96);
+    }
+
+    function hasDecreaseTimeWithin(uint256 _start, uint256 _end) public pure returns (bool) {
+        return isWednesdayBetween(_start, _end);
+    }
+
+    function getElapsedMinutes(uint256 _start, uint256 _end) public pure returns (uint256) {
+        require(_start <= _end, "Start time must be <= end");
+
+        uint256 elapsedSeconds = _end - _start;
+        uint256 elapsedMinutes = elapsedSeconds / 60;
+
+        return elapsedMinutes;
+    }
+
+    function isWednesdayBetween(uint256 start, uint256 end) public pure returns (bool) {
+        require(start <= end, "Start time must be <= end");
+        if (start == end) {
+            return false;
+        }
+        uint256 startDay = start / 1 days;
+        uint256 endDay = end / 1 days;
+        if (startDay == endDay) {
+            return false;
+        }
+
+        // 0 = Thursday, 1 = Friday, 2 = Saturday, ..., 6 = Wednesday
+        uint256 startWeekday = startDay % 7;
+        uint256 endWeekday = endDay % 7;
+
+        if (startWeekday != 6 && startWeekday >= endWeekday) {
+            return true;
+        } else if (endWeekday == 6) {
+            return true;
+        } else {
+            uint256 startWeek = startDay / 7;
+            uint256 endWeek = endDay / 7;
+            return startWeek != endWeek;
+        }
+    }
+
+    // for polygon bridge
+    function deposit(address user, bytes calldata depositData) external {
+        require(msg.sender == polygonChainManager, "Only polygon chain manager can call this function");
+        uint256 amount = abi.decode(depositData, (uint256));
+        _mint(user, amount);
+    }
+
+    function withdraw(uint256 amount) external {
+        _burn(_msgSender(), amount);
+    }
+
+    function _authorizeUpgrade(address newImplementation) internal virtual override onlyOwner { }
+
+    function version() public pure returns (string memory) {
+        return "1.0.11";
+    }
+}

--- a/test/PCEV11.t.sol
+++ b/test/PCEV11.t.sol
@@ -1,0 +1,308 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import {Test, console2} from "forge-std/Test.sol";
+import {PCECommunityTokenV11} from "../src/PCECommunityTokenV11.sol";
+import {PCEToken} from "../src/PCEToken.sol";
+import {PCETokenV11} from "../src/PCETokenV11.sol";
+import {ExchangeAllowMethod} from "../src/lib/Enum.sol";
+import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
+import {Utils} from "../src/lib/Utils.sol";
+
+// Minimal Beacon for testing
+contract MinimalBeaconV11 {
+    address public implementation;
+    address public owner;
+
+    constructor(address initialImplementation) {
+        implementation = initialImplementation;
+        owner = msg.sender;
+    }
+
+    function upgradeTo(address newImplementation) public {
+        require(msg.sender == owner, "Ownable: caller is not the owner");
+        implementation = newImplementation;
+    }
+}
+
+// Minimal UUPS Proxy for testing
+contract MinimalUUPSProxyV11 {
+    address public implementation;
+    address public owner;
+
+    constructor(address initialImplementation) {
+        implementation = initialImplementation;
+        owner = msg.sender;
+    }
+
+    function upgradeTo(address newImplementation) public {
+        require(msg.sender == owner, "Ownable: caller is not the owner");
+        implementation = newImplementation;
+    }
+
+    fallback() external payable {
+        _delegate(implementation);
+    }
+
+    receive() external payable {
+        _delegate(implementation);
+    }
+
+    function _delegate(address _implementation) internal virtual {
+        assembly {
+            calldatacopy(0, 0, calldatasize())
+            let result := delegatecall(gas(), _implementation, 0, calldatasize(), 0, 0)
+            returndatacopy(0, 0, returndatasize())
+            switch result
+            case 0 { revert(0, returndatasize()) }
+            default { return(0, returndatasize()) }
+        }
+    }
+}
+
+contract PCEV11Test is Test {
+    PCETokenV11 public pceToken;
+    PCECommunityTokenV11 public token;
+    MinimalBeaconV11 public pceCommunityTokenBeacon;
+    address public owner;
+    address public user1;
+    address public user2;
+
+    function setUp() public {
+        owner = address(this);
+        user1 = address(0x1);
+        user2 = address(0x2);
+
+        vm.startPrank(owner);
+
+        PCECommunityTokenV11 communityImpl = new PCECommunityTokenV11();
+        PCEToken pceTokenV1 = new PCEToken();
+        PCETokenV11 pceTokenV11Impl = new PCETokenV11();
+
+        pceCommunityTokenBeacon = new MinimalBeaconV11(address(communityImpl));
+
+        MinimalUUPSProxyV11 pceTokenProxy = new MinimalUUPSProxyV11(address(pceTokenV1));
+        PCEToken(address(pceTokenProxy)).initialize(
+            "PCE Token",
+            "PCE",
+            address(pceCommunityTokenBeacon),
+            address(0x687C1D2dd0F422421BeF7aC2a52f50e858CAA867)
+        );
+
+        pceTokenProxy.upgradeTo(address(pceTokenV11Impl));
+        pceToken = PCETokenV11(address(pceTokenProxy));
+
+        pceToken.mint(owner, 10000 ether);
+
+        address[] memory incomeTargetTokens = new address[](0);
+        address[] memory outgoTargetTokens = new address[](0);
+
+        pceToken.createToken(
+            "Test Community Token",
+            "TCT",
+            1000 ether,
+            1 ether,   // 1:1 dilution
+            1,         // decrease interval days
+            9800,      // after decrease bp (98%)
+            1000,      // max increase of total supply bp
+            500,       // max increase bp
+            1000,      // max usage bp
+            100,       // change bp
+            ExchangeAllowMethod.All,
+            ExchangeAllowMethod.All,
+            incomeTargetTokens,
+            outgoTargetTokens
+        );
+
+        vm.stopPrank();
+
+        address[] memory tokens_ = pceToken.getTokens();
+        token = PCECommunityTokenV11(tokens_[0]);
+    }
+
+    function testSwapFromLocalToken() public {
+        vm.startPrank(owner);
+        uint256 swapAmount = 100 ether;
+        pceToken.swapToLocalToken(address(token), swapAmount);
+
+        uint256 communityBalance = token.balanceOf(owner);
+        assertTrue(communityBalance > 0, "Should have community tokens after swap");
+
+        // Advance time by 1 day so midnightBalance gets set
+        vm.warp(block.timestamp + 1 days);
+        token.transfer(user1, 1 ether);
+
+        // Advance another day
+        vm.warp(block.timestamp + 1 days);
+
+        uint256 swapBackAmount = 10 ether;
+        uint256 pceBalanceBefore = pceToken.balanceOf(owner);
+
+        pceToken.swapFromLocalToken(address(token), swapBackAmount);
+
+        uint256 pceBalanceAfter = pceToken.balanceOf(owner);
+        assertTrue(pceBalanceAfter > pceBalanceBefore, "PCE balance should increase after swap from local");
+
+        vm.stopPrank();
+    }
+
+    function testSwapFromLocalTokenWithoutApprove() public {
+        vm.startPrank(owner);
+
+        pceToken.swapToLocalToken(address(token), 100 ether);
+
+        vm.warp(block.timestamp + 1 days);
+        token.transfer(user1, 1 ether);
+        vm.warp(block.timestamp + 1 days);
+
+        uint256 communityBalanceBefore = token.balanceOf(owner);
+        pceToken.swapFromLocalToken(address(token), 5 ether);
+        uint256 communityBalanceAfter = token.balanceOf(owner);
+
+        assertTrue(communityBalanceAfter < communityBalanceBefore, "Community tokens should decrease");
+
+        vm.stopPrank();
+    }
+
+    function testBurnByPCETokenOnlyCallableByPCEToken() public {
+        vm.startPrank(owner);
+        token.mint(owner, 100 ether);
+        vm.stopPrank();
+
+        vm.startPrank(user1);
+        vm.expectRevert("Only PCE token");
+        token.burnByPCEToken(owner, 10 ether);
+        vm.stopPrank();
+    }
+
+    function testRecordSwapToPCEOnlyCallableByPCEToken() public {
+        vm.startPrank(user1);
+        vm.expectRevert("Only PCE token");
+        token.recordSwapToPCE(user1, 10 ether);
+        vm.stopPrank();
+    }
+
+    function testRemainingBalanceDecreasesAfterSwap() public {
+        vm.startPrank(owner);
+
+        pceToken.swapToLocalToken(address(token), 100 ether);
+
+        // Advance time so midnightBalance gets set
+        vm.warp(block.timestamp + 1 days);
+        token.transfer(user1, 1 ether);
+        vm.warp(block.timestamp + 1 days);
+
+        uint256 remainingBefore = token.getRemainingSwapableToPCEBalanceForIndividual(owner);
+        assertTrue(remainingBefore > 0, "Should have remaining swapable balance");
+
+        uint256 globalRemainingBefore = token.getRemainingSwapableToPCEBalance();
+        assertTrue(globalRemainingBefore > 0, "Should have global remaining swapable balance");
+
+        // Do a swap
+        uint256 swapAmount = 5 ether;
+        pceToken.swapFromLocalToken(address(token), swapAmount);
+
+        uint256 remainingAfter = token.getRemainingSwapableToPCEBalanceForIndividual(owner);
+        uint256 globalRemainingAfter = token.getRemainingSwapableToPCEBalance();
+
+        assertEq(remainingBefore - remainingAfter, swapAmount, "Individual remaining should decrease by swapAmount");
+        assertEq(globalRemainingBefore - globalRemainingAfter, swapAmount, "Global remaining should decrease by swapAmount");
+
+        vm.stopPrank();
+    }
+
+    function testRevertOnExceedingDailyLimit() public {
+        vm.startPrank(owner);
+
+        pceToken.swapToLocalToken(address(token), 500 ether);
+
+        // Advance time so midnightBalance gets set
+        vm.warp(block.timestamp + 1 days);
+        token.transfer(user1, 1 ether);
+        vm.warp(block.timestamp + 1 days);
+
+        uint256 remaining = token.getRemainingSwapableToPCEBalance();
+        console2.log("Global remaining swapable:", remaining);
+
+        // If remaining is 0, the limit is already exceeded from setup
+        if (remaining == 0) {
+            vm.expectRevert("Exceeds daily swap limit");
+            pceToken.swapFromLocalToken(address(token), 1 ether);
+        } else {
+            // Swap exactly the remaining amount (should succeed)
+            if (remaining > 0) {
+                pceToken.swapFromLocalToken(address(token), remaining);
+            }
+
+            // Now any additional swap should revert
+            vm.expectRevert("Exceeds daily swap limit");
+            pceToken.swapFromLocalToken(address(token), 1 ether);
+        }
+
+        vm.stopPrank();
+    }
+
+    function testRevertOnExceedingIndividualDailyLimit() public {
+        vm.startPrank(owner);
+
+        pceToken.swapToLocalToken(address(token), 500 ether);
+
+        // Transfer some community tokens to user1
+        vm.warp(block.timestamp + 1 days);
+        token.transfer(user1, 200 ether);
+        vm.warp(block.timestamp + 1 days);
+
+        vm.stopPrank();
+
+        vm.startPrank(user1);
+
+        uint256 individualRemaining = token.getRemainingSwapableToPCEBalanceForIndividual(user1);
+        console2.log("Individual remaining swapable for user1:", individualRemaining);
+
+        if (individualRemaining > 0) {
+            pceToken.swapFromLocalToken(address(token), individualRemaining);
+
+            // Now it should revert
+            vm.expectRevert("Exceeds daily individual swap limit");
+            pceToken.swapFromLocalToken(address(token), 1 ether);
+        }
+
+        vm.stopPrank();
+    }
+
+    function testDailyLimitResetsAfterDayPasses() public {
+        vm.startPrank(owner);
+
+        pceToken.swapToLocalToken(address(token), 500 ether);
+
+        // Advance time so midnightBalance gets set
+        vm.warp(block.timestamp + 1 days);
+        token.transfer(user1, 1 ether);
+        vm.warp(block.timestamp + 1 days);
+
+        uint256 remainingBefore = token.getRemainingSwapableToPCEBalance();
+        assertTrue(remainingBefore > 0, "Should have remaining balance");
+
+        // Swap some
+        uint256 swapAmount = 3 ether;
+        require(remainingBefore >= swapAmount, "Not enough remaining for test");
+        pceToken.swapFromLocalToken(address(token), swapAmount);
+
+        uint256 remainingAfterSwap = token.getRemainingSwapableToPCEBalance();
+        assertTrue(remainingAfterSwap < remainingBefore, "Remaining should decrease");
+
+        // Advance to next day (2 days to ensure intervalDaysOf detects crossing)
+        vm.warp(block.timestamp + 2 days);
+
+        uint256 remainingAfterReset = token.getRemainingSwapableToPCEBalance();
+        // After day reset, used resets to 0, so remaining == full daily limit
+        assertTrue(remainingAfterReset > remainingAfterSwap, "Remaining should reset after day passes");
+
+        vm.stopPrank();
+    }
+
+    function testVersion() public view {
+        assertEq(pceToken.version(), "1.0.11");
+        assertEq(token.version(), "1.0.11");
+    }
+}


### PR DESCRIPTION
## Summary
- **バグ修正**: `swapFromLocalToken` で同日に複数回呼ぶと日次限度額を超えて回収できる問題を修正
- **新機能**: グローバル/個人別の日次回収累計トラッキング (`recordSwapToPCE`)
- **新View**: `getRemainingSwapableToPCEBalance()` / `getRemainingSwapableToPCEBalanceForIndividual(address)` でUI側からリアルタイムに残り回収可能量を取得可能に

## Changes
| ファイル | 内容 |
|---------|------|
| `src/PCECommunityTokenV11.sol` | 状態変数追加 + `recordSwapToPCE` + `getRemaining~` viewメソッド |
| `src/PCETokenV11.sol` | `swapFromLocalToken` のチェックを `getRemaining~` に変更 + `recordSwapToPCE` 呼出追加 |
| `test/PCEV11.t.sol` | 9テスト（残量減少確認、限度額超過revert、日次リセット等） |
| `docs/v11-new-methods.md` | UI設計者向けの新メソッド仕様書 |
| `script/Upgrade.s.sol` | V11へのアップグレード参照 |
| `script/UpgradeDEV.s.sol` | V11へのアップグレード参照（DEV） |

## Test plan
- [x] `forge test --match-contract PCEV11Test -vvv` — 9テスト全通過
- [x] `forge test --match-contract PCEV10Test` — 既存V10テストに影響なし
- [ ] DEV環境でアップグレードスクリプト実行確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)