### PR TITLE
feat: v12 security hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@ As of v11, a single file per contract is used and versioning is managed through 
 - Fix fee drain in `transferFromWithAuthorization` — include fee in allowance check and spend
 - Add zero-amount transfer guard to `transferWithAuthorization` and `transferFromWithAuthorization`
 - Replace `ecrecover` with `ECRecover.recover` in `transferFromWithAuthorization`, `setInfinityApproveFlagWithAuthorization`, and `claimVoucherWithAuthorization` (address(0) guard + signature malleability protection)
-- Add `maxMetaTransactionFee` cap to prevent fee manipulation attacks (`setMaxMetaTransactionFee`, applied in `getMetaTransactionFee` / `getMetaTransactionFeeWithBaseFee`)
 - Add address(0) validation for all meta-transaction function parameters
 - Fix `_mintArigatoCreation` to use `storage` instead of `memory` for `AccountInfo`, enabling per-sender cumulative mint tracking
 - Rewrite `getCurrentFactor` with O(log n) binary exponentiation for correct multi-period decay (PCECommunityToken and PCEToken)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ As of v11, a single file per contract is used and versioning is managed through 
 - Add `recordSwapToPCE`, `getRemainingSwapableToPCEBalance`, `getRemainingSwapableToPCEBalanceForIndividual`
 - Remove console2.log from production code
 - Consolidate versioned files into single PCEToken.sol / PCECommunityToken.sol
+- Fix fee drain in `transferFromWithAuthorization` — include fee in allowance check and spend
+- Add zero-amount transfer guard to `transferWithAuthorization` and `transferFromWithAuthorization`
+- Replace `ecrecover` with `ECRecover.recover` in `transferFromWithAuthorization`, `setInfinityApproveFlagWithAuthorization`, and `claimVoucherWithAuthorization` (address(0) guard + signature malleability protection)
+- Add `maxMetaTransactionFee` cap to prevent fee manipulation attacks (`setMaxMetaTransactionFee`, applied in `getMetaTransactionFee` / `getMetaTransactionFeeWithBaseFee`)
+- Add address(0) validation for all meta-transaction function parameters
+- Fix `_mintArigatoCreation` to use `storage` instead of `memory` for `AccountInfo`, enabling per-sender cumulative mint tracking
+- Rewrite `getCurrentFactor` with O(log n) binary exponentiation for correct multi-period decay (PCECommunityToken and PCEToken)
+- Fix `updateFactorIfNeeded` to advance `lastDecreaseTime` to decay boundary instead of `block.timestamp`
+- Replace `isWednesdayBetween` with `countWednesdaysBetween` for accurate multi-Wednesday counting in PCEToken
+- Fix `midnightTotalSupply` initialization to use `super.totalSupply()` instead of transfer amount
+- Add explicit underflow guard in `swapFromLocalToken` for deposited PCE token reserve
 
 ## v10
 - Fix `swapFromLocalToken` with daily global/individual swap caps

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,7 @@ All notable changes to the PCEToken and PCECommunityToken contracts are document
 Version numbering was previously tracked via separate contract files (e.g., PCETokenV2.sol).
 As of v11, a single file per contract is used and versioning is managed through git history.
 
-## v11
-- Add daily swap-to-PCE tracking to prevent limit bypass (global and individual)
-- Replace `burnFrom` with `burnByPCEToken` in `swapFromLocalToken` (no user approval needed)
-- Add `recordSwapToPCE`, `getRemainingSwapableToPCEBalance`, `getRemainingSwapableToPCEBalanceForIndividual`
-- Remove console2.log from production code
-- Consolidate versioned files into single PCEToken.sol / PCECommunityToken.sol
+## v12
 - Fix fee drain in `transferFromWithAuthorization` — include fee in allowance check and spend
 - Add zero-amount transfer guard to `transferWithAuthorization` and `transferFromWithAuthorization`
 - Replace `ecrecover` with `ECRecover.recover` in `transferFromWithAuthorization`, `setInfinityApproveFlagWithAuthorization`, and `claimVoucherWithAuthorization` (address(0) guard + signature malleability protection)
@@ -21,6 +16,13 @@ As of v11, a single file per contract is used and versioning is managed through 
 - Replace `isWednesdayBetween` with `countWednesdaysBetween` for accurate multi-Wednesday counting in PCEToken
 - Fix `midnightTotalSupply` initialization to use `super.totalSupply()` instead of transfer amount
 - Add explicit underflow guard in `swapFromLocalToken` for deposited PCE token reserve
+
+## v11
+- Add daily swap-to-PCE tracking to prevent limit bypass (global and individual)
+- Replace `burnFrom` with `burnByPCEToken` in `swapFromLocalToken` (no user approval needed)
+- Add `recordSwapToPCE`, `getRemainingSwapableToPCEBalance`, `getRemainingSwapableToPCEBalanceForIndividual`
+- Remove console2.log from production code
+- Consolidate versioned files into single PCEToken.sol / PCECommunityToken.sol
 
 ## v10
 - Fix `swapFromLocalToken` with daily global/individual swap caps

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,7 @@ git push origin v12
 
 - `src/PCEToken.sol` — Main PCE token (UUPS upgradeable proxy)
 - `src/PCECommunityToken.sol` — Community tokens (Beacon proxy, one per community)
-- `script/UpgradeDEV.s.sol` — DEV environment upgrade (Polygon Amoy)
+- `script/UpgradeDEV.s.sol` — DEV environment upgrade (Polygon mainnet)
 - `script/Upgrade.s.sol` — Production upgrade (Polygon mainnet)
 - `script/upgrade.sh` — Upgrade wrapper with storage layout validation
 
@@ -51,7 +51,7 @@ git push origin v12
 
 ## Contract Addresses
 
-### DEV (Polygon Amoy)
+### DEV (Polygon mainnet)
 - PCEToken proxy: `0x62Ef93EAa5bB3E47E0e855C323ef156c8E3D8913`
 - PCECommunityToken beacon: `0xA9D965660dcF0fA73E709fd802e9DEF2d9b52952`
 

--- a/src/PCECommunityToken.sol
+++ b/src/PCECommunityToken.sol
@@ -392,7 +392,7 @@ contract PCECommunityToken is
     }
 
     function mint(address to, uint256 displayBalance) external {
-        require(_msgSender() == owner() || _msgSender() == pceAddress, "Only owner or PCE token");
+        require(_msgSender() == pceAddress, "Only PCE token");
         updateFactorIfNeeded();
         _mint(to, displayBalanceToRawBalance(displayBalance));
     }

--- a/src/PCECommunityToken.sol
+++ b/src/PCECommunityToken.sol
@@ -947,6 +947,6 @@ contract PCECommunityToken is
     }
 
     function version() public pure returns (string memory) {
-        return "1.0.11";
+        return "1.0.12";
     }
 }

--- a/src/PCECommunityToken.sol
+++ b/src/PCECommunityToken.sol
@@ -685,13 +685,18 @@ contract PCECommunityToken is
         public
     {
         updateFactorIfNeeded();
+
+        // Input address validation
+        require(owner != address(0), "Invalid owner address");
+        require(spender != address(0), "Invalid spender address");
+
         uint256 displayFee = getMetaTransactionFee();
         uint256 rawFee = displayBalanceToRawBalance(displayFee);
 
         require(block.timestamp > validAfter, "Not yet valid");
         require(block.timestamp < validBefore, "Authorization expired");
         require(!_authorizationStates[owner][nonce], "Authorization used");
-        require(super.balanceOf(owner) >= (rawFee), "Insufficient balance");
+        require(super.balanceOf(owner) >= rawFee, "Insufficient balance");
 
         bytes memory data = abi.encode(
             SET_INFINITY_APPROVE_FLAG_WITH_AUTHORIZATION_TYPEHASH,
@@ -708,8 +713,9 @@ contract PCECommunityToken is
             keccak256(data)
         ));
 
+        // Use ECRecover.recover for address(0) guard
         require(
-            ecrecover(digest, v, r, s) == owner,
+            ECRecover.recover(digest, v, r, s) == owner,
             "Invalid signature"
         );
 

--- a/src/PCECommunityToken.sol
+++ b/src/PCECommunityToken.sol
@@ -253,7 +253,8 @@ contract PCECommunityToken is
         uint256 remainingArigatoCreationMintToday = maxArigatoCreationMintToday - mintArigatoCreationToday;
         uint256 remainingArigatoCreationMintTodayForGuest;
 
-        AccountInfo memory accountInfo = _accountInfos[sender];
+        // Use storage to persist individual mint tracking across transactions
+        AccountInfo storage accountInfo = _accountInfos[sender];
 
         bool isGuest = accountInfo.firstTransactionTime == accountInfo.lastModifiedMidnightBalanceTime;
         if (isGuest) {
@@ -285,15 +286,27 @@ contract PCECommunityToken is
             mintAmount = remainingArigatoCreationMintToday;
         }
 
-        // ** Sender mint limit
+        // ** Sender mint limit (with cumulative tracking via storage)
+        // mintArigatoCreationToday initial value is 1 (gas optimization), subtract 1 for actual minted
+        uint256 actualMinted = accountInfo.mintArigatoCreationToday > 0
+            ? accountInfo.mintArigatoCreationToday - 1
+            : 0;
+
         if (!isGuest) {
             uint256 maxArigatoCreationMintTodayForSender =
                 Math.mulDiv(maxArigatoCreationMintToday, accountInfo.midnightBalance, midnightTotalSupply);
             if (maxArigatoCreationMintTodayForSender <= 0) {
                 return;
             }
-            if (mintAmount > maxArigatoCreationMintTodayForSender) {
-                mintAmount = maxArigatoCreationMintTodayForSender;
+            // Check cumulative sender limit
+            uint256 remainingSenderCap = maxArigatoCreationMintTodayForSender > actualMinted
+                ? maxArigatoCreationMintTodayForSender - actualMinted
+                : 0;
+            if (remainingSenderCap == 0) {
+                return;
+            }
+            if (mintAmount > remainingSenderCap) {
+                mintAmount = remainingSenderCap;
             }
         } else {
             // Guest can mint only 1% of maxArigatoCreationMintToday
@@ -304,8 +317,15 @@ contract PCECommunityToken is
             if (maxArigatoCreationMintTodayForGuestSender <= 0) {
                 return;
             }
-            if (mintAmount > maxArigatoCreationMintTodayForGuestSender) {
-                mintAmount = maxArigatoCreationMintTodayForGuestSender;
+            // Check cumulative guest sender limit
+            uint256 remainingGuestSenderCap = maxArigatoCreationMintTodayForGuestSender > actualMinted
+                ? maxArigatoCreationMintTodayForGuestSender - actualMinted
+                : 0;
+            if (remainingGuestSenderCap == 0) {
+                return;
+            }
+            if (mintAmount > remainingGuestSenderCap) {
+                mintAmount = remainingGuestSenderCap;
             }
         }
 

--- a/src/PCECommunityToken.sol
+++ b/src/PCECommunityToken.sol
@@ -524,6 +524,10 @@ contract PCECommunityToken is
         uint256 rawAmount = displayBalanceToRawBalance(displayAmount);
         uint256 displayFee = getMetaTransactionFee();
         uint256 rawFee = displayBalanceToRawBalance(displayFee);
+
+        // Prevent zero-amount transfer that only charges fee
+        require(rawAmount > 0, "Amount must be greater than zero");
+
         _transferWithAuthorization(from, to, displayAmount, validAfter, validBefore, nonce, v, r, s, rawAmount);
 
         super._transfer(from, _msgSender(), rawFee);

--- a/src/PCECommunityToken.sol
+++ b/src/PCECommunityToken.sol
@@ -153,10 +153,20 @@ contract PCECommunityToken is
         PCEToken pceToken = PCEToken(pceAddress);
         pceToken.updateFactorIfNeeded();
 
+        if (decreaseIntervalDays == 0) return;
+
+        uint256 startDay = lastDecreaseTime / 1 days;
+        uint256 endDay = block.timestamp / 1 days;
+        if (endDay <= startDay) return;
+        uint256 elapsed = endDay - startDay;
+        if (elapsed < decreaseIntervalDays) return;
+
+        uint256 times = elapsed / decreaseIntervalDays;
         uint256 currentFactor = getCurrentFactor();
         if (currentFactor != lastModifiedFactor) {
             lastModifiedFactor = currentFactor;
-            lastDecreaseTime = block.timestamp;
+            // Advance to the last decay boundary, not block.timestamp
+            lastDecreaseTime = (startDay + (times * decreaseIntervalDays)) * 1 days;
         }
     }
 

--- a/src/PCECommunityToken.sol
+++ b/src/PCECommunityToken.sol
@@ -202,7 +202,8 @@ contract PCECommunityToken is
 
     function _beforeTokenTransfer(address from, address to, uint256 amount) internal {
         if (midnightTotalSupplyModifiedTime == 0) {
-            midnightTotalSupply = amount;
+            // Use total supply instead of transfer amount to prevent manipulation
+            midnightTotalSupply = super.totalSupply();
             midnightTotalSupplyModifiedTime = block.timestamp;
         } else if (intervalDaysOf(midnightTotalSupplyModifiedTime, block.timestamp, 1)) {
             midnightTotalSupply = super.totalSupply();

--- a/src/PCECommunityToken.sol
+++ b/src/PCECommunityToken.sol
@@ -11,6 +11,7 @@ import { PCEToken } from "./PCEToken.sol";
 import { Utils } from "./lib/Utils.sol";
 import { EIP3009 } from "./lib/EIP3009.sol";
 import { EIP712 } from "./lib/EIP712.sol";
+import { ECRecover } from "./lib/ECRecover.sol";
 import { TokenSetting } from "./lib/TokenSetting.sol";
 import { ExchangeAllowMethod } from "./lib/Enum.sol";
 import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
@@ -543,16 +544,30 @@ contract PCECommunityToken is
         public
     {
         updateFactorIfNeeded();
+
+        // Input address validation
+        require(spender != address(0), "Invalid spender address");
+        require(from != address(0), "Invalid from address");
+        require(to != address(0), "Invalid to address");
+
         uint256 rawBalance = super.balanceOf(from);
         uint256 rawAmount = displayBalanceToRawBalance(displayAmount);
         uint256 displayFee = getMetaTransactionFee();
         uint256 rawFee = displayBalanceToRawBalance(displayFee);
 
+        // Prevent zero-amount fee drain attack
+        require(rawAmount > 0, "Amount must be greater than zero");
+
         require(block.timestamp > validAfter, "Not yet valid");
         require(block.timestamp < validBefore, "Authorization expired");
         require(!_authorizationStates[spender][nonce], "Authorization used");
         require(rawBalance >= (rawAmount + rawFee), "Insufficient balance");
-        require(_infinityApproveFlags[from][spender] || super.allowance(from, spender) >= rawAmount, "Insufficient allowance");
+        // Include fee in allowance check
+        require(
+            _infinityApproveFlags[from][spender]
+                || super.allowance(from, spender) >= (rawAmount + rawFee),
+            "Insufficient allowance"
+        );
 
         bytes memory data = abi.encode(
             TRANSFER_FROM_WITH_AUTHORIZATION_TYPEHASH,
@@ -570,15 +585,17 @@ contract PCECommunityToken is
             keccak256(data)
         ));
 
+        // Use ECRecover.recover for address(0) guard
         require(
-            ecrecover(digest, v, r, s) == spender,
+            ECRecover.recover(digest, v, r, s) == spender,
             "Invalid signature"
         );
 
         _authorizationStates[spender][nonce] = true;
         emit AuthorizationUsed(spender, nonce);
 
-        _spendAllowance(from, spender, rawAmount);
+        // Include fee in allowance spend
+        _spendAllowance(from, spender, rawAmount + rawFee);
         super._transfer(from, to, rawAmount);
         super._transfer(from, _msgSender(), rawFee);
 

--- a/src/PCECommunityToken.sol
+++ b/src/PCECommunityToken.sol
@@ -792,6 +792,10 @@ contract PCECommunityToken is
         external
     {
         updateFactorIfNeeded();
+
+        // Input address validation
+        require(claimer != address(0), "Invalid claimer address");
+
         uint256 displayFee = getMetaTransactionFee();
         uint256 rawFee = displayBalanceToRawBalance(displayFee);
 
@@ -810,7 +814,8 @@ contract PCECommunityToken is
         );
         bytes32 digest = keccak256(abi.encodePacked("\x19\x01", this.DOMAIN_SEPARATOR(), keccak256(data)));
 
-        require(ecrecover(digest, v, r, s) == claimer, "Invalid signature");
+        // Use ECRecover.recover for address(0) guard
+        require(ECRecover.recover(digest, v, r, s) == claimer, "Invalid signature");
 
         _authorizationStates[claimer][nonce] = true;
         emit AuthorizationUsed(claimer, nonce);

--- a/src/PCECommunityToken.sol
+++ b/src/PCECommunityToken.sol
@@ -120,11 +120,29 @@ contract PCECommunityToken is
         if (decreaseIntervalDays == 0) {
             return lastModifiedFactor;
         }
-        if (intervalDaysOf(lastDecreaseTime, block.timestamp, decreaseIntervalDays)) {
-            return Math.mulDiv(lastModifiedFactor, afterDecreaseBp, BP_BASE);
-        } else {
+        uint256 startDay = lastDecreaseTime / 1 days;
+        uint256 endDay = block.timestamp / 1 days;
+        if (endDay <= startDay) {
             return lastModifiedFactor;
         }
+        uint256 elapsed = endDay - startDay;
+        if (elapsed < decreaseIntervalDays) {
+            return lastModifiedFactor;
+        }
+        // Apply multiple decay periods via O(log n) exponentiation
+        uint256 times = elapsed / decreaseIntervalDays;
+        uint256 factor = lastModifiedFactor;
+        uint256 rate = afterDecreaseBp;
+        uint256 base = BP_BASE;
+        uint256 n = times;
+        while (n > 0) {
+            if (n % 2 == 1) {
+                factor = Math.mulDiv(factor, rate, base);
+            }
+            rate = Math.mulDiv(rate, rate, base);
+            n /= 2;
+        }
+        return factor;
     }
 
     function updateFactorIfNeeded() public {

--- a/src/PCEToken.sol
+++ b/src/PCEToken.sol
@@ -75,11 +75,24 @@ contract PCEToken is
         if (lastModifiedFactor == 0) {
             return 0;
         }
-        if (hasDecreaseTimeWithin(lastDecreaseTime, block.timestamp)) {
-            return Math.mulDiv(lastModifiedFactor, DECREASE_RATE, DECREASE_RATE_BASE);
-        } else {
+        // Count actual Wednesdays crossed for multiple-week decay
+        uint256 times = countWednesdaysBetween(lastDecreaseTime, block.timestamp);
+        if (times == 0) {
             return lastModifiedFactor;
         }
+        // O(log n) exponentiation
+        uint256 factor = lastModifiedFactor;
+        uint256 rate = DECREASE_RATE;
+        uint256 base = DECREASE_RATE_BASE;
+        uint256 n = times;
+        while (n > 0) {
+            if (n % 2 == 1) {
+                factor = Math.mulDiv(factor, rate, base);
+            }
+            rate = Math.mulDiv(rate, rate, base);
+            n /= 2;
+        }
+        return factor;
     }
 
     function updateFactorIfNeeded() public {
@@ -87,10 +100,17 @@ contract PCEToken is
             return;
         }
 
+        uint256 times = countWednesdaysBetween(lastDecreaseTime, block.timestamp);
+        if (times == 0) return;
+
         uint256 currentFactor = getCurrentFactor();
         if (currentFactor != lastModifiedFactor) {
             lastModifiedFactor = currentFactor;
-            lastDecreaseTime = block.timestamp;
+            // Advance to the last Wednesday boundary, not block.timestamp
+            uint256 endDay = block.timestamp / 1 days;
+            uint256 endWeekday = endDay % 7;
+            uint256 lastWedDay = endDay - ((endWeekday + 1) % 7);
+            lastDecreaseTime = lastWedDay * 1 days;
         }
     }
 
@@ -321,30 +341,27 @@ contract PCEToken is
         return elapsedMinutes;
     }
 
-    function isWednesdayBetween(uint256 start, uint256 end) public pure returns (bool) {
-        require(start <= end, "Start time must be <= end");
-        if (start == end) {
-            return false;
-        }
+    /// @notice Count the number of Wednesdays strictly between start and end timestamps.
+    /// Start day (if Wednesday) is excluded; the next Wednesday is the first counted.
+    function countWednesdaysBetween(uint256 start, uint256 end) public pure returns (uint256) {
         uint256 startDay = start / 1 days;
         uint256 endDay = end / 1 days;
-        if (startDay == endDay) {
-            return false;
-        }
+        if (startDay >= endDay) return 0;
 
-        // 0 = Thursday, 1 = Friday, 2 = Saturday, ..., 6 = Wednesday
-        uint256 startWeekday = startDay % 7;
-        uint256 endWeekday = endDay % 7;
+        // Find the first Wednesday strictly after startDay
+        // 0=Thursday, 1=Friday, ..., 6=Wednesday
+        uint256 nextDay = startDay + 1;
+        uint256 nextWeekday = nextDay % 7;
+        uint256 daysToNextWed = (6 - nextWeekday + 7) % 7;
+        uint256 firstWed = nextDay + daysToNextWed;
 
-        if (startWeekday != 6 && startWeekday >= endWeekday) {
-            return true;
-        } else if (endWeekday == 6) {
-            return true;
-        } else {
-            uint256 startWeek = startDay / 7;
-            uint256 endWeek = endDay / 7;
-            return startWeek != endWeek;
-        }
+        if (firstWed > endDay) return 0;
+        return ((endDay - firstWed) / 7) + 1;
+    }
+
+    function isWednesdayBetween(uint256 start, uint256 end) public pure returns (bool) {
+        require(start <= end, "Start time must be <= end");
+        return countWednesdaysBetween(start, end) > 0;
     }
 
     // for polygon bridge

--- a/src/PCEToken.sol
+++ b/src/PCEToken.sol
@@ -384,6 +384,6 @@ contract PCEToken is
     function _authorizeUpgrade(address newImplementation) internal virtual override onlyOwner { }
 
     function version() public pure returns (string memory) {
-        return "1.0.11";
+        return "1.0.12";
     }
 }

--- a/src/PCEToken.sol
+++ b/src/PCEToken.sol
@@ -289,11 +289,17 @@ contract PCEToken is
         require(target.getRemainingSwapableToPCEBalance() >= amountToSwap, "Exceeds daily swap limit");
         require(target.getRemainingSwapableToPCEBalanceForIndividual(_msgSender()) >= amountToSwap, "Exceeds daily individual swap limit");
 
+        // Explicit underflow guard with clear error message
+        require(
+            localTokens[fromToken].depositedPCEToken >= pcetokenAmount,
+            "Insufficient deposited PCE token reserve"
+        );
+
         target.burnByPCEToken(_msgSender(), amountToSwap);
         target.recordSwapToPCE(_msgSender(), amountToSwap);
         _transfer(address(this), _msgSender(), pcetokenAmount);
 
-        localTokens[fromToken].depositedPCEToken = localTokens[fromToken].depositedPCEToken - pcetokenAmount;
+        localTokens[fromToken].depositedPCEToken -= pcetokenAmount;
 
         emit TokensSwappedFromLocalToken(_msgSender(), fromToken, amountToSwap, pcetokenAmount);
     }

--- a/test/PCE.t.sol
+++ b/test/PCE.t.sol
@@ -133,12 +133,19 @@ contract PCETest is Test {
 
     function testBurnByPCETokenOnlyCallableByPCEToken() public {
         vm.startPrank(owner);
-        token.mint(owner, 100 ether);
+        pceToken.swapToLocalToken(address(token), 100 ether);
         vm.stopPrank();
 
         vm.startPrank(user1);
         vm.expectRevert("Only PCE token");
         token.burnByPCEToken(owner, 10 ether);
+        vm.stopPrank();
+    }
+
+    function testMintOnlyCallableByPCEToken() public {
+        vm.startPrank(owner);
+        vm.expectRevert("Only PCE token");
+        token.mint(owner, 100 ether);
         vm.stopPrank();
     }
 

--- a/test/PCE.t.sol
+++ b/test/PCE.t.sol
@@ -269,7 +269,7 @@ contract PCETest is Test {
     }
 
     function testVersion() public view {
-        assertEq(pceToken.version(), "1.0.11");
-        assertEq(token.version(), "1.0.11");
+        assertEq(pceToken.version(), "1.0.12");
+        assertEq(token.version(), "1.0.12");
     }
 }


### PR DESCRIPTION
## Summary
- Rewrite getCurrentFactor with O(log n) binary exponentiation (PCECommunityToken) [`5867dbd`](https://github.com/peacecoin-protocol/core/commit/5867dbd)
- Advance lastDecreaseTime to decay boundary in updateFactorIfNeeded (PCECommunityToken) [`b856f24`](https://github.com/peacecoin-protocol/core/commit/b856f24)
- Initialize midnightTotalSupply with totalSupply() instead of transfer amount [`3e71be3`](https://github.com/peacecoin-protocol/core/commit/3e71be3)
- Use storage for AccountInfo in _mintArigatoCreation with cumulative tracking [`6195e06`](https://github.com/peacecoin-protocol/core/commit/6195e06)
- Add zero-amount guard to transferWithAuthorization [`cfbc8b7`](https://github.com/peacecoin-protocol/core/commit/cfbc8b7)
- Harden transferFromWithAuthorization against fee drain attack [`88a0da7`](https://github.com/peacecoin-protocol/core/commit/88a0da7)
- Replace ecrecover with ECRecover.recover in setInfinityApproveFlagWithAuthorization [`fce8e1d`](https://github.com/peacecoin-protocol/core/commit/fce8e1d)
- Replace ecrecover with ECRecover.recover in claimVoucherWithAuthorization [`92cec3c`](https://github.com/peacecoin-protocol/core/commit/92cec3c)
- Rewrite factor decay with countWednesdaysBetween in PCEToken [`6ac1eef`](https://github.com/peacecoin-protocol/core/commit/6ac1eef)
- Add underflow guard in swapFromLocalToken [`d264016`](https://github.com/peacecoin-protocol/core/commit/d264016)
- Restrict CommunityToken mint to PCEToken only [`590e869`](https://github.com/peacecoin-protocol/core/commit/590e869)
- Add v12 security fix entries to CHANGELOG [`8595f73`](https://github.com/peacecoin-protocol/core/commit/8595f73)
- Bump version to v12 [`6cb9cfa`](https://github.com/peacecoin-protocol/core/commit/6cb9cfa)

## Test plan
- [x] `forge build` succeeds
- [x] `forge test` all 23 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)