### PR TITLE
feat: add upgrade.sh with storage layout validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@ package-lock.json
 pnpm-lock.yaml
 yarn.lock
 
+# upgrade reference build (temporary worktree)
+.upgrade-reference-build
+
 # broadcasts
 !broadcast
 broadcast/*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,60 @@
+# PCE Token Core
+
+Solidity smart contracts for PCEToken (ERC20, UUPS proxy) and PCECommunityToken (ERC20, Beacon proxy) on Polygon.
+
+## Build & Test
+
+```bash
+forge build
+forge test
+```
+
+## Upgrade Contracts
+
+Always use `script/upgrade.sh` for upgrades. Do NOT run `forge script` directly for upgrade scripts — the OZ storage layout check will fail without a reference contract.
+
+```bash
+# Previous version tag is auto-detected from the latest git tag.
+
+# DEV
+./script/upgrade.sh script/UpgradeDEV.s.sol --broadcast --fork-url polygon --interactives 1
+
+# Production
+./script/upgrade.sh script/Upgrade.s.sol --broadcast --fork-url polygon --interactives 1
+
+# Override auto-detection if needed
+PREV_TAG=v10 ./script/upgrade.sh script/UpgradeDEV.s.sol --broadcast --fork-url polygon --interactives 1
+```
+
+The script validates storage layout compatibility by building the previous version from a git tag, then runs the forge script with the OZ check skipped (since it was already done externally via CLI).
+
+**After each upgrade, tag the release:**
+
+```bash
+git tag v12
+git push origin v12
+```
+
+## Key Architecture
+
+- `src/PCEToken.sol` — Main PCE token (UUPS upgradeable proxy)
+- `src/PCECommunityToken.sol` — Community tokens (Beacon proxy, one per community)
+- `script/UpgradeDEV.s.sol` — DEV environment upgrade (Polygon Amoy)
+- `script/Upgrade.s.sol` — Production upgrade (Polygon mainnet)
+- `script/upgrade.sh` — Upgrade wrapper with storage layout validation
+
+## Versioning
+
+- Versions are tracked via git tags (v2, v4, v5, v6, v8, v9, v10, v11, ...)
+- Pre-v11: versioned files (`PCETokenV10.sol`), post-v11: single files with git history
+- `version()` function in each contract returns the current version string (e.g., `"1.0.11"`)
+
+## Contract Addresses
+
+### DEV (Polygon Amoy)
+- PCEToken proxy: `0x62Ef93EAa5bB3E47E0e855C323ef156c8E3D8913`
+- PCECommunityToken beacon: `0xA9D965660dcF0fA73E709fd802e9DEF2d9b52952`
+
+### Production (Polygon mainnet)
+- PCEToken proxy: `0xA4807a8C34353A5EA51aF073175950Cb6248dA7E`
+- PCECommunityToken beacon: `0x6A73A610707C113F34D8B82498b6868e5f7FAA74`

--- a/README.md
+++ b/README.md
@@ -154,6 +154,42 @@ Deploy to Polygon Amoy:
 $ forge script script/Deploy.s.sol --broadcast --fork-url amoy --interactives 1
 ```
 
+### Upgrade
+
+Use `script/upgrade.sh` to upgrade deployed contracts. This wrapper script automatically validates storage layout
+compatibility against the previous version before executing the forge upgrade script.
+
+```sh
+# Usage: ./script/upgrade.sh <FORGE_SCRIPT> [FORGE_ARGS...]
+# The previous version is auto-detected from the latest git tag.
+
+# DEV environment (Polygon Amoy)
+$ ./script/upgrade.sh script/UpgradeDEV.s.sol --broadcast --fork-url polygon --interactives 1
+
+# Production (Polygon mainnet)
+$ ./script/upgrade.sh script/Upgrade.s.sol --broadcast --fork-url polygon --interactives 1
+
+# Override auto-detection if needed
+$ PREV_TAG=v10 ./script/upgrade.sh script/UpgradeDEV.s.sol --broadcast --fork-url polygon --interactives 1
+```
+
+**How it works:**
+
+1. Checks out the previous version (git tag) into a temporary worktree and builds it
+2. Runs OpenZeppelin's `upgrades-core` CLI to validate storage layout compatibility between the previous and current versions
+3. If validation passes, executes the forge upgrade script
+4. Cleans up temporary files automatically
+
+This approach works with both pre-consolidation tags (v2-v10, where contracts were named `PCETokenV10.sol` etc.)
+and post-consolidation tags (v11+, where contracts use `PCEToken.sol`).
+
+**Important:** After each upgrade, tag the release:
+
+```sh
+$ git tag v12
+$ git push origin v12
+```
+
 ### Format
 
 Format the contracts:

--- a/script/Upgrade.s.sol
+++ b/script/Upgrade.s.sol
@@ -3,15 +3,19 @@ pragma solidity >=0.8.26 <0.9.0;
 
 import { BaseScript } from "./Base.s.sol";
 
-import { Upgrades } from "openzeppelin-foundry-upgrades/Upgrades.sol";
+import { Upgrades, Options } from "openzeppelin-foundry-upgrades/Upgrades.sol";
 
 /// @dev See the Solidity Scripting tutorial: https://book.getfoundry.sh/tutorials/solidity-scripting
+/// Storage layout validation is performed by script/upgrade.sh before this script runs.
 contract Upgrade is BaseScript {
     function run() public broadcast {
         address pceTokenAddress = 0xA4807a8C34353A5EA51aF073175950Cb6248dA7E;
         address pceCommunityTokenAddress = 0x6A73A610707C113F34D8B82498b6868e5f7FAA74;
 
-        Upgrades.upgradeProxy(pceTokenAddress, "PCEToken.sol:PCEToken", "");
-        Upgrades.upgradeBeacon(pceCommunityTokenAddress, "PCECommunityToken.sol:PCECommunityToken");
+        Options memory opts;
+        opts.unsafeSkipStorageCheck = true;
+
+        Upgrades.upgradeProxy(pceTokenAddress, "PCEToken.sol:PCEToken", "", opts);
+        Upgrades.upgradeBeacon(pceCommunityTokenAddress, "PCECommunityToken.sol:PCECommunityToken", opts);
     }
 }

--- a/script/UpgradeDEV.s.sol
+++ b/script/UpgradeDEV.s.sol
@@ -3,15 +3,19 @@ pragma solidity >=0.8.26 <0.9.0;
 
 import { BaseScript } from "./Base.s.sol";
 
-import { Upgrades } from "openzeppelin-foundry-upgrades/Upgrades.sol";
+import { Upgrades, Options } from "openzeppelin-foundry-upgrades/Upgrades.sol";
 
 /// @dev See the Solidity Scripting tutorial: https://book.getfoundry.sh/tutorials/solidity-scripting
+/// Storage layout validation is performed by script/upgrade.sh before this script runs.
 contract UpgradeDEV is BaseScript {
     function run() public broadcast {
         address pceTokenAddress = 0x62Ef93EAa5bB3E47E0e855C323ef156c8E3D8913;
         address pceCommunityTokenAddress = 0xA9D965660dcF0fA73E709fd802e9DEF2d9b52952;
 
-        Upgrades.upgradeProxy(pceTokenAddress, "PCEToken.sol:PCEToken", "");
-        Upgrades.upgradeBeacon(pceCommunityTokenAddress, "PCECommunityToken.sol:PCECommunityToken");
+        Options memory opts;
+        opts.unsafeSkipStorageCheck = true;
+
+        Upgrades.upgradeProxy(pceTokenAddress, "PCEToken.sol:PCEToken", "", opts);
+        Upgrades.upgradeBeacon(pceCommunityTokenAddress, "PCECommunityToken.sol:PCECommunityToken", opts);
     }
 }

--- a/script/upgrade.sh
+++ b/script/upgrade.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Usage: ./script/upgrade.sh <FORGE_SCRIPT> [FORGE_ARGS...]
+# Example: ./script/upgrade.sh script/UpgradeDEV.s.sol --broadcast --fork-url polygon
+#
+# The previous version tag is auto-detected from the latest git tag.
+# To override: PREV_TAG=v10 ./script/upgrade.sh script/UpgradeDEV.s.sol --broadcast --fork-url polygon
+
+SCRIPT="${1:?Usage: $0 <FORGE_SCRIPT> [FORGE_ARGS...]}"
+shift 1
+
+PREV_TAG="${PREV_TAG:-$(git describe --tags --abbrev=0 2>/dev/null)}"
+if [ -z "$PREV_TAG" ]; then
+    echo "ERROR: No git tags found. Tag the current deployed version first: git tag v11"
+    exit 1
+fi
+
+WORKTREE_DIR=".upgrade-reference-build"
+REF_BUILD_INFO="/tmp/oz-upgrade-ref-build-info-$$"
+
+cleanup() {
+    git worktree remove --force "$WORKTREE_DIR" 2>/dev/null || true
+    rm -rf "$REF_BUILD_INFO"
+}
+trap cleanup EXIT
+
+# Step 1: Build previous version from git tag
+echo "==> Building previous version from tag: $PREV_TAG"
+git worktree add --detach "$WORKTREE_DIR" "$PREV_TAG" 2>/dev/null
+(cd "$WORKTREE_DIR" && forge build --skip test --skip script 2>&1) | tail -3
+
+# Copy build-info to a temp dir with a unique name (OZ requires unique dir short names)
+mkdir -p "$REF_BUILD_INFO"
+cp "$WORKTREE_DIR/out/build-info/"*.json "$REF_BUILD_INFO/"
+git worktree remove --force "$WORKTREE_DIR" 2>/dev/null
+
+# Step 2: Build current version
+echo "==> Building current version"
+forge clean
+forge build
+
+# Step 3: Validate storage layout compatibility
+echo "==> Validating upgrade safety (storage layout check)"
+REF_DIR_NAME="$(basename "$REF_BUILD_INFO")"
+ERRORS=0
+
+validate_contract() {
+    local contract="$1"
+    local candidates="$2"
+
+    for candidate in $candidates; do
+        if npx @openzeppelin/upgrades-core@^1.32.3 validate out/build-info \
+            --contract "$contract" \
+            --reference "$REF_DIR_NAME:$candidate" \
+            --referenceBuildInfoDirs "$REF_BUILD_INFO" 2>/dev/null; then
+            echo "  $contract: OK (reference: $candidate)"
+            return 0
+        fi
+    done
+    echo "  $contract: FAILED"
+    return 1
+}
+
+# Try matching reference contract names.
+# Versioned filenames (V20..V1) are tried first, then the consolidated filename.
+# This ensures we compare against the latest version at that tag, not the V1 original.
+# Pre-consolidation versions used both versioned contract names (PCETokenVN) and filenames.
+PCE_CANDIDATES=""
+for v in $(seq 20 -1 1); do
+    PCE_CANDIDATES="$PCE_CANDIDATES src/PCETokenV${v}.sol:PCETokenV${v}"
+    PCE_CANDIDATES="$PCE_CANDIDATES src/PCETokenV${v}.sol:PCEToken"
+done
+PCE_CANDIDATES="$PCE_CANDIDATES src/PCEToken.sol:PCEToken"
+
+COMMUNITY_CANDIDATES=""
+for v in $(seq 20 -1 1); do
+    COMMUNITY_CANDIDATES="$COMMUNITY_CANDIDATES src/PCECommunityTokenV${v}.sol:PCECommunityTokenV${v}"
+    COMMUNITY_CANDIDATES="$COMMUNITY_CANDIDATES src/PCECommunityTokenV${v}.sol:PCECommunityToken"
+done
+COMMUNITY_CANDIDATES="$COMMUNITY_CANDIDATES src/PCECommunityToken.sol:PCECommunityToken"
+
+validate_contract "src/PCEToken.sol:PCEToken" "$PCE_CANDIDATES" || ERRORS=1
+validate_contract "src/PCECommunityToken.sol:PCECommunityToken" "$COMMUNITY_CANDIDATES" || ERRORS=1
+
+if [ "$ERRORS" -ne 0 ]; then
+    echo "ERROR: Storage layout validation failed. Aborting upgrade."
+    exit 1
+fi
+
+# Step 4: Run forge script (skip OZ's built-in check since we already validated)
+echo "==> Running forge script"
+FOUNDRY_UPGRADES_UNSAFE_SKIP_STORAGE_CHECK=true forge script "$SCRIPT" "$@"


### PR DESCRIPTION
## Summary
- Add `script/upgrade.sh` — wrapper that auto-detects the previous version from git tags, builds it in a temporary worktree, validates storage layout compatibility via OZ `upgrades-core` CLI, then runs forge script
- Update `Upgrade.s.sol` / `UpgradeDEV.s.sol` to skip OZ's built-in storage check (already validated by the wrapper)
- Add upgrade instructions to `README.md` and project overview to `CLAUDE.md`

## Background
After consolidating versioned contract files (e.g. `PCETokenV10.sol`) into single files (`PCEToken.sol`), OZ's upgrade safety validation could no longer find a reference contract. This script resolves that by dynamically building the previous version from git history — no extra source files needed in the repo.

## Test plan
- [x] `./script/upgrade.sh script/UpgradeDEV.s.sol --fork-url polygon` — auto-detects v11, validates, runs successfully
- [x] `./script/upgrade.sh script/UpgradeDEV.s.sol --fork-url polygon` with `PREV_TAG=v10` — correctly resolves `PCETokenV10` reference
- [x] Works with both pre-consolidation (v10) and post-consolidation (v11) tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)