### PR TITLE
fix: correct depreciation factor inversion in balance conversion

### DIFF
--- a/src/PCECommunityToken.sol
+++ b/src/PCECommunityToken.sol
@@ -103,6 +103,7 @@ contract PCECommunityToken is
     event InfinityApproveFlagSet(address indexed owner, address indexed spender, bool flag);
 
     function initialize(string memory name, string memory symbol, uint256 _initialFactor) public initializer {
+        require(_initialFactor > 0, "Initial factor must be > 0");
         __ERC20_init(name, symbol);
         __Ownable_init(_msgSender());
         __ERC20Permit_init(name);
@@ -175,7 +176,7 @@ contract PCECommunityToken is
         if (currentFactor < 1) {
             currentFactor = 1;
         }
-        return rawBalance / currentFactor;
+        return Math.mulDiv(rawBalance, currentFactor, initialFactor * initialFactor);
     }
 
     function displayBalanceToRawBalance(uint256 displayBalance) public view returns (uint256) {
@@ -183,7 +184,7 @@ contract PCECommunityToken is
         if (currentFactor < 1) {
             currentFactor = 1;
         }
-        return displayBalance * currentFactor;
+        return Math.mulDiv(displayBalance, initialFactor * initialFactor, currentFactor);
     }
 
     function totalSupply() public view override returns (uint256) {
@@ -946,6 +947,6 @@ contract PCECommunityToken is
     }
 
     function version() public pure returns (string memory) {
-        return "1.0.12";
+        return "1.0.13";
     }
 }

--- a/test/PCE.t.sol
+++ b/test/PCE.t.sol
@@ -273,8 +273,83 @@ contract PCETest is Test {
         vm.stopPrank();
     }
 
+    function testCommunityTokenDepreciatesOverTime() public {
+        vm.startPrank(owner);
+
+        // Decrease interval is 1 day, afterDecreaseBp = 9800 (98%)
+        uint256 day1 = block.timestamp + 1 days;
+        uint256 day2 = block.timestamp + 2 days;
+
+        // Swap PCE to community token
+        pceToken.swapToLocalToken(address(token), 100 ether);
+        uint256 balanceAtSwap = token.balanceOf(owner);
+        assertTrue(balanceAtSwap > 0, "Should have community tokens after swap");
+
+        // Advance 1 day
+        vm.warp(day1);
+
+        uint256 balanceAfter1Day = token.balanceOf(owner);
+        assertLt(balanceAfter1Day, balanceAtSwap, "Display balance should DECREASE after 1 day (depreciation)");
+
+        // Advance 2 days from start
+        vm.warp(day2);
+
+        uint256 balanceAfter2Days = token.balanceOf(owner);
+        assertLt(balanceAfter2Days, balanceAfter1Day, "Display balance should continue decreasing");
+
+        // Verify the depreciation rate is approximately 2% per day
+        uint256 expectedAfter1Day = balanceAtSwap * 98 / 100;
+        assertApproxEqAbs(balanceAfter1Day, expectedAfter1Day, 1, "Should be ~98% after 1 day");
+
+        uint256 expectedAfter2Days = balanceAtSwap * 9604 / 10000;
+        assertApproxEqAbs(balanceAfter2Days, expectedAfter2Days, 1, "Should be ~96.04% after 2 days");
+
+        vm.stopPrank();
+    }
+
+    function testNewMintAfterDepreciationShowsCorrectBalance() public {
+        vm.startPrank(owner);
+
+        uint256 day1 = block.timestamp + 1 days;
+        uint256 day2 = block.timestamp + 2 days;
+
+        // First swap at day 0
+        pceToken.swapToLocalToken(address(token), 100 ether);
+        uint256 firstMintBalance = token.balanceOf(owner);
+
+        // Advance 1 day (factor depreciates by 2%)
+        vm.warp(day1);
+
+        uint256 depreciated = token.balanceOf(owner);
+        assertLt(depreciated, firstMintBalance, "First mint should have depreciated");
+
+        // Second swap at day 1 (same 100 PCE as first swap)
+        pceToken.swapToLocalToken(address(token), 100 ether);
+        uint256 totalAfterSecondMint = token.balanceOf(owner);
+        uint256 secondMintDelta = totalAfterSecondMint - depreciated;
+
+        // Verify second mint delta matches the full swap formula in swapToLocalToken:
+        // targetTokenAmount = amountToSwap * exchangeRate / INITIAL_FACTOR * communityFactor / pceFactor
+        uint256 exchangeRate = pceToken.getExchangeRate(address(token));
+        uint256 expectedSecondMint = 100 ether * exchangeRate / 1e18 * token.getCurrentFactor() / pceToken.getCurrentFactor();
+        assertApproxEqAbs(secondMintDelta, expectedSecondMint, 1, "Second mint should match swap formula at day 1");
+
+        // Advance 2 days from start - all tokens should depreciate
+        vm.warp(day2);
+        uint256 allDepreciated = token.balanceOf(owner);
+        assertLt(allDepreciated, totalAfterSecondMint, "All tokens should depreciate after another day");
+
+        // Verify combined depreciation:
+        // - First swap tokens (minted at day 0): depreciated 2 periods → 98% × 98% = 96.04%
+        // - Second swap tokens (minted at day 1): depreciated 1 period → 98%
+        uint256 expectedDay2 = depreciated * 98 / 100 + secondMintDelta * 98 / 100;
+        assertApproxEqAbs(allDepreciated, expectedDay2, 1, "Day 2 total should match combined depreciation");
+
+        vm.stopPrank();
+    }
+
     function testVersion() public view {
         assertEq(pceToken.version(), "1.0.12");
-        assertEq(token.version(), "1.0.12");
+        assertEq(token.version(), "1.0.13");
     }
 }


### PR DESCRIPTION
## Summary

- Fix inverted factor logic in `rawBalanceToDisplayBalance` and `displayBalanceToRawBalance` that causes **display balances to increase over time** instead of correctly depreciating
- Use `Math.mulDiv` with `initialFactor²` as the scaling constant to correctly apply depreciation
- Add 2 tests verifying correct depreciation behavior

## Bug Details

The conversion functions had the factor relationship inverted:

```solidity
// BEFORE (bug): as currentFactor decreases, display balance INCREASES
//   rawToDisplay = raw / currentFactor  →  smaller divisor = bigger result
//   displayToRaw = display * currentFactor  →  smaller multiplier = smaller result
return rawBalance / currentFactor;
return displayBalance * currentFactor;

// AFTER (fix): as currentFactor decreases, display balance correctly DECREASES
//   rawToDisplay = raw × currentFactor / initialFactor²  →  smaller numerator = smaller result
//   displayToRaw = display × initialFactor² / currentFactor  →  smaller divisor = bigger result
return Math.mulDiv(rawBalance, currentFactor, initialFactor * initialFactor);
return Math.mulDiv(displayBalance, initialFactor * initialFactor, currentFactor);
```

At token creation (`currentFactor == initialFactor`), both formulas produce identical results. The divergence grows as `currentFactor` decays over time.

## Mainnet Impact Analysis (if deployed 2026-03-13 11:00 UTC)

### Upgrade mechanism

PCECommunityToken uses **Beacon proxy** — upgrading the beacon implementation atomically upgrades **all** community tokens in a single transaction.

### What changes immediately

All view functions that use `rawBalanceToDisplayBalance` will return **lower** values:
- `balanceOf(address)` — every holder's displayed balance decreases
- `totalSupply()` — displayed total supply decreases
- `allowance(owner, spender)` — displayed allowances decrease

**No raw (internal ERC-20 storage) balances change.** Only the display interpretation is corrected.

### Production tokens (11 tokens)

| Token | Balance Δ | totalSupply Before | totalSupply After |
|-------|-----------|-------------------|-------------------|
| ADSDEV1 | **-0.40%** | 100.20 | 99.80 |
| ADSDEV2 | **-0.40%** | 1,002.00 | 998.00 |
| ADEV5 | **-0.80%** | 1,003,039.89 | 995,039.61 |
| ALOHA | **-1.19%** | 1,007,256.65 | 995,229.84 |
| JETSTREAM | **-0.40%** | 1,003,378.30 | 999,368.80 |
| ADSDEV3 | **-0.40%** | 1,002.00 | 998.00 |
| TOKYO | **-2.37%** | 10,187.83 | 9,946.00 |
| Somicコイン | **-0.40%** | 100,202.32 | 99,801.91 |
| KANPAI | **-1.59%** | 101,187.99 | 99,580.27 |
| クマガヤコイン | **-0.40%** | 100,204.41 | 99,803.99 |
| PCE Developers | **-1.19%** | 252,541.37 | 249,525.98 |

**Worst case: TOKYO at -2.37%.** Most tokens see -0.40% (1 decay period of 0.2%).

The change ratio formula is `(currentFactor / initialFactor)²` — tokens that have been through more decay periods since creation show a larger correction.

### DEV tokens (42 tokens, sample)

| Token | Balance Δ |
|-------|-----------|
| TEST1 | -6.61% |
| NOODLE | -11.39% |
| ホロコイン | -9.00% |
| ラオーラコイン | -11.39% |

DEV tokens show larger corrections because they have been active longer relative to their creation.

### Behavioral change going forward

| Behavior | Before (bug) | After (fix) |
|----------|-------------|-------------|
| `balanceOf()` over time | Increases (wrong) | Decreases (correct) |
| `transfer(100)` raw cost | Decreases over time | Increases over time |
| Arigato Creation mint base | Inflated amounts | Correct amounts |
| Meta-tx fee (community token) | Under-charged in raw | Correctly charged |

### What is NOT affected

- PCEToken itself (separate UUPS proxy, not part of this change)
- Raw ERC-20 storage balances (`super.balanceOf()`)
- Token settings (decreaseIntervalDays, afterDecreaseBp, etc.)
- Community-to-community swaps via `swapTokens()` (uses raw amounts internally)

### Limitation: residual discrepancy from operations performed under the buggy formula

This fix corrects the `rawToDisplay` / `displayToRaw` conversion formulas, but does **not** retroactively fix raw balances that were stored using the buggy `displayToRaw`.

**Operations at token creation (t=0)** are unaffected — at that point `currentFactor == initialFactor`, so both formulas produce identical raw values.

**Operations after factor decay** stored incorrect raw amounts. For example, a mint of 50 display tokens at `currentFactor = initialFactor × 0.98`:

```
Buggy displayToRaw(50)   = 50 × initialFactor × 0.98       (stored)
Correct displayToRaw(50) = 50 × initialFactor / 0.98       (what should have been stored)
Ratio = 0.98² ≈ 0.9604  →  ~4% fewer raw tokens were stored than correct
```

After the fix is applied, these under-stored raw balances are interpreted with the correct formula:

```
With fix:       (100×iF + 50×iF×0.98) × 0.98 / iF = 98 + 48.02 = 146.02
Never-had-bug:  (100×iF + 50×iF/0.98) × 0.98 / iF = 98 + 50    = 148.00
```

| Scenario | Correctly restored? |
|----------|-------------------|
| Tokens minted at creation (t=0, `currentFactor == initialFactor`) | **Yes** — both formulas produce identical raw values |
| Tokens minted/transferred/swapped after factor decay | **No** — raw values stored under buggy `displayToRaw` remain as-is |
| All future operations after upgrade | **Yes** — correct formula applied going forward |

**Practical impact**: Production tokens decay at 0.2%/week, and most token activity (initial mints via `createToken`/`swapToLocalToken`) happens at or near creation time. The residual discrepancy from post-decay operations is expected to be minimal. Fully correcting this would require a raw balance migration (rescaling), which is out of scope for this fix.

## Test plan

- [x] `testCommunityTokenDepreciatesOverTime` — verifies 2%/day decay produces correct display balances at day 1 and day 2
- [x] `testNewMintAfterDepreciationShowsCorrectBalance` — verifies mints after depreciation show correct balances
- [x] All existing tests pass (25 tests)

---

<details>
<summary>日本語の説明</summary>

### バグの内容

`rawBalanceToDisplayBalance` と `displayBalanceToRawBalance` の factor 計算が逆転しており、時間経過で表示残高が減少ではなく**増加**してしまうバグ。

```solidity
// 修正前（バグ）: currentFactor が減少すると表示残高が増加してしまう
//   rawToDisplay = raw / currentFactor → 除数が小さくなる = 結果が大きくなる
//   displayToRaw = display * currentFactor → 乗数が小さくなる = 結果が小さくなる
return rawBalance / currentFactor;
return displayBalance * currentFactor;

// 修正後: currentFactor が減少すると表示残高が正しく減少する
//   rawToDisplay = raw × currentFactor / initialFactor² → 分子が小さくなる = 結果が小さくなる
//   displayToRaw = display × initialFactor² / currentFactor → 除数が小さくなる = 結果が大きくなる
return Math.mulDiv(rawBalance, currentFactor, initialFactor * initialFactor);
return Math.mulDiv(displayBalance, initialFactor * initialFactor, currentFactor);
```

トークン作成時（`currentFactor == initialFactor`）には新旧どちらの式も同じ結果を返す。factor が減衰するにつれ差が広がる。

### 本番環境への影響 (2026-03-13 11:00 UTC デプロイ想定)

#### アップグレード方式

PCECommunityToken は **Beacon proxy** を使用しているため、beacon の実装をアップグレードするだけで**すべて**のコミュニティトークンが1トランザクションで一斉にアップグレードされる。

#### 即時の変化

`rawBalanceToDisplayBalance` を使用するすべての view 関数の戻り値が**小さく**なる:
- `balanceOf(address)` — 全保有者の表示残高が減少
- `totalSupply()` — 表示される総供給量が減少
- `allowance(owner, spender)` — 表示される許可額が減少

**内部の raw 残高（ERC-20 ストレージ）は変化しない。** 表示の解釈が正しくなるだけ。

#### 本番トークン（11トークン）

| トークン | 残高変動 | totalSupply 修正前 | totalSupply 修正後 |
|---------|---------|-------------------|-------------------|
| ADSDEV1 | **-0.40%** | 100.20 | 99.80 |
| ADSDEV2 | **-0.40%** | 1,002.00 | 998.00 |
| ADEV5 | **-0.80%** | 1,003,039.89 | 995,039.61 |
| ALOHA | **-1.19%** | 1,007,256.65 | 995,229.84 |
| JETSTREAM | **-0.40%** | 1,003,378.30 | 999,368.80 |
| ADSDEV3 | **-0.40%** | 1,002.00 | 998.00 |
| TOKYO | **-2.37%** | 10,187.83 | 9,946.00 |
| Somicコイン | **-0.40%** | 100,202.32 | 99,801.91 |
| KANPAI | **-1.59%** | 101,187.99 | 99,580.27 |
| クマガヤコイン | **-0.40%** | 100,204.41 | 99,803.99 |
| PCE Developers | **-1.19%** | 252,541.37 | 249,525.98 |

**最悪ケース: TOKYO の -2.37%。** 大半のトークンは -0.40%（減衰1回分 0.2%）。

変動率の計算式は `(currentFactor / initialFactor)²` — 作成後の減衰回数が多いトークンほど補正幅が大きい。

#### DEV トークン（42トークン、サンプル）

| トークン | 残高変動 |
|---------|---------|
| TEST1 | -6.61% |
| NOODLE | -11.39% |
| ホロコイン | -9.00% |
| ラオーラコイン | -11.39% |

DEV トークンは作成からの経過が長いため、補正幅が大きい。

#### 修正前後の動作変化

| 動作 | 修正前（バグ） | 修正後 |
|------|-------------|--------|
| `balanceOf()` の時間経過 | 増加する（誤り） | 減少する（正しい） |
| `transfer(100)` の raw コスト | 時間とともに減少 | 時間とともに増加 |
| Arigato Creation の mint 基準 | 膨張した金額 | 正しい金額 |
| メタトランザクション手数料 | raw で過少徴収 | 正しく徴収 |

#### 影響を受けない箇所

- PCEToken 本体（別の UUPS proxy、今回の変更対象外）
- raw ERC-20 ストレージ残高（`super.balanceOf()`）
- トークン設定（decreaseIntervalDays, afterDecreaseBp 等）
- コミュニティ間スワップ `swapTokens()`（内部的に raw 金額を使用）

#### 制限事項: バグのある式で実行された操作による残余誤差

この修正は `rawToDisplay` / `displayToRaw` の変換式を正しくするが、バグのある `displayToRaw` で保存された **raw 残高を遡及的に修正するものではない**。

**トークン作成時（t=0）の操作**は影響なし — その時点では `currentFactor == initialFactor` なので、新旧どちらの式でも同じ raw 値が保存される。

**factor 減衰後の操作**は不正確な raw 額が保存されている。例: `currentFactor = initialFactor × 0.98` 時の 50 トークン mint:

```
バグ版 displayToRaw(50) = 50 × initialFactor × 0.98     （実際に保存された値）
正式 displayToRaw(50)   = 50 × initialFactor / 0.98     （本来保存されるべき値）
比率 = 0.98² ≈ 0.9604 → 正しい値より約 4% 少ない raw が保存されている
```

修正適用後、この過少な raw 残高を正しい式で解釈するため:

```
修正適用後:    (100×iF + 50×iF×0.98) × 0.98 / iF = 98 + 48.02 = 146.02
バグなしなら:  (100×iF + 50×iF/0.98) × 0.98 / iF = 98 + 50    = 148.00
```

| ケース | 正しく復元されるか |
|--------|-----------------|
| 作成時（t=0, `currentFactor == initialFactor`）の mint | **Yes** — 新旧の式で同一の raw 値 |
| factor 減衰後の mint / transfer / swap | **No** — バグ版 `displayToRaw` で保存された raw 値がそのまま残る |
| アップグレード後の今後の操作 | **Yes** — 正しい式が適用される |

**実際の影響度**: 本番トークンの減衰率は週 0.2% で、大半のトークン操作（`createToken` / `swapToLocalToken` による初期 mint）は作成直後に集中している。そのため、減衰後の操作による残余誤差は微小と見込まれる。完全に正しい状態にするには raw 残高のマイグレーション（リスケーリング）が必要だが、本修正のスコープ外とする。

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)