### PR TITLE
feat: PIP-13 Meta-Transaction Fee Auto-Swap to PCE

### DIFF
--- a/src/PCECommunityToken.sol
+++ b/src/PCECommunityToken.sol
@@ -100,6 +100,7 @@ contract PCECommunityToken is
     event PCETransfer(address indexed from, address indexed to, uint256 displayAmount, uint256 rawAmount);
     event MintArigatoCreation(address indexed to, uint256 displayAmount, uint256 rawAmount);
     event MetaTransactionFeeCollected(address indexed from, address indexed to, uint256 displayFee, uint256 rawFee);
+    event MetaTransactionFeeSwapped(address indexed from, address indexed relayer, uint256 communityTokenFee, uint256 pceFee);
     event InfinityApproveFlagSet(address indexed owner, address indexed spender, bool flag);
 
     function initialize(string memory name, string memory symbol, uint256 _initialFactor) public initializer {
@@ -513,6 +514,15 @@ contract PCECommunityToken is
         return Math.mulDiv(pceTokenFee, rate, 2**96);
     }
 
+    function _collectFeeAsPCE(address from, address relayer, uint256 displayFee) internal returns (uint256) {
+        uint256 rawFee = displayBalanceToRawBalance(displayFee);
+        _burn(from, rawFee);
+        PCEToken pceToken = PCEToken(pceAddress);
+        uint256 pceAmount = pceToken.swapFeeFromLocalToken(address(this), relayer, displayFee);
+        emit MetaTransactionFeeSwapped(from, relayer, displayFee, pceAmount);
+        return pceAmount;
+    }
+
     function transferWithAuthorization(
         address from, address to, uint256 displayAmount, uint256 validAfter, uint256 validBefore, bytes32 nonce, uint8 v, bytes32 r, bytes32 s
     )
@@ -523,16 +533,13 @@ contract PCECommunityToken is
         uint256 rawBalance = super.balanceOf(from);
         uint256 rawAmount = displayBalanceToRawBalance(displayAmount);
         uint256 displayFee = getMetaTransactionFee();
-        uint256 rawFee = displayBalanceToRawBalance(displayFee);
 
         // Prevent zero-amount transfer that only charges fee
         require(rawAmount > 0, "Amount must be greater than zero");
 
         _transferWithAuthorization(from, to, displayAmount, validAfter, validBefore, nonce, v, r, s, rawAmount);
 
-        super._transfer(from, _msgSender(), rawFee);
-
-        emit MetaTransactionFeeCollected(from, _msgSender(), displayFee, rawFee);
+        _collectFeeAsPCE(from, _msgSender(), displayFee);
 
         _mintArigatoCreation(from, rawAmount, rawBalance, 1);
     }
@@ -596,9 +603,8 @@ contract PCECommunityToken is
         // Include fee in allowance spend
         _spendAllowance(from, spender, rawAmount + rawFee);
         super._transfer(from, to, rawAmount);
-        super._transfer(from, _msgSender(), rawFee);
+        _collectFeeAsPCE(from, _msgSender(), displayFee);
 
-        emit MetaTransactionFeeCollected(from, _msgSender(), displayFee, rawFee);
         _mintArigatoCreation(from, rawAmount, rawBalance, 1);
     }
 
@@ -725,8 +731,7 @@ contract PCECommunityToken is
         emit InfinityApproveFlagSet(owner, spender, flag);
 
         // Collect meta transaction fee from owner
-        super._transfer(owner, _msgSender(), rawFee);
-        emit MetaTransactionFeeCollected(owner, _msgSender(), displayFee, rawFee);
+        _collectFeeAsPCE(owner, _msgSender(), displayFee);
     }
 
     // Voucher functions
@@ -835,9 +840,8 @@ contract PCECommunityToken is
         // Transfer amount after fee to claimer
         super._transfer(address(this), claimer, amountAfterFee);
 
-        // Collect meta transaction fee from claimed amount
-        super._transfer(address(this), _msgSender(), rawFee);
-        emit MetaTransactionFeeCollected(claimer, _msgSender(), displayFee, rawFee);
+        // Collect meta transaction fee from claimed amount (swap to PCE for relayer)
+        _collectFeeAsPCE(address(this), _msgSender(), displayFee);
     }
 
     function getVoucherIssuanceInfo(string memory issuanceId)
@@ -946,6 +950,6 @@ contract PCECommunityToken is
     }
 
     function version() public pure returns (string memory) {
-        return "1.0.12";
+        return "1.0.13";
     }
 }

--- a/src/PCEToken.sol
+++ b/src/PCEToken.sol
@@ -46,6 +46,9 @@ contract PCEToken is
     event TokensSwappedFromLocalToken(
         address indexed to, address indexed fromToken, uint256 targetTokenAmount, uint256 pceTokenAmount
     );
+    event FeeSwappedFromLocalToken(
+        address indexed fromToken, address indexed relayer, uint256 communityTokenAmount, uint256 pceAmount
+    );
 
     uint256 public constant INITIAL_FACTOR = 10 ** 18;
     uint256 private constant Q96 = 2 ** 96;
@@ -307,6 +310,40 @@ contract PCEToken is
         emit TokensSwappedFromLocalToken(_msgSender(), fromToken, amountToSwap, pcetokenAmount);
     }
 
+    function swapFeeFromLocalToken(
+        address fromToken,
+        address relayer,
+        uint256 communityTokenDisplayAmount
+    )
+        external
+        returns (uint256)
+    {
+        require(msg.sender == fromToken, "Caller must be the community token");
+        require(localTokens[fromToken].isExists, "Token not registered");
+
+        updateFactorIfNeeded();
+
+        PCECommunityToken target = PCECommunityToken(fromToken);
+
+        uint256 pcetokenAmount = Math.mulDiv(
+            Math.mulDiv(communityTokenDisplayAmount, INITIAL_FACTOR, localTokens[fromToken].exchangeRate),
+            lastModifiedFactor,
+            target.getCurrentFactor()
+        );
+        require(pcetokenAmount > 0, "Fee swap amount too small");
+        require(
+            localTokens[fromToken].depositedPCEToken >= pcetokenAmount,
+            "Insufficient deposited PCE token reserve"
+        );
+
+        _transfer(address(this), relayer, pcetokenAmount);
+        localTokens[fromToken].depositedPCEToken -= pcetokenAmount;
+
+        emit FeeSwappedFromLocalToken(fromToken, relayer, communityTokenDisplayAmount, pcetokenAmount);
+
+        return pcetokenAmount;
+    }
+
     function getNativeTokenToPceTokenRate() public view returns (uint256) {
         return nativeTokenToPceTokenRate;
     }
@@ -387,6 +424,6 @@ contract PCEToken is
     function _authorizeUpgrade(address newImplementation) internal virtual override onlyOwner { }
 
     function version() public pure returns (string memory) {
-        return "1.0.12";
+        return "1.0.13";
     }
 }

--- a/test/PCE.t.sol
+++ b/test/PCE.t.sol
@@ -274,7 +274,184 @@ contract PCETest is Test {
     }
 
     function testVersion() public view {
-        assertEq(pceToken.version(), "1.0.12");
-        assertEq(token.version(), "1.0.12");
+        assertEq(pceToken.version(), "1.0.13");
+        assertEq(token.version(), "1.0.13");
+    }
+
+    // --- PIP-3: Meta-Transaction Fee Auto-Swap Tests ---
+
+    function _makeDomainSeparator(address tokenAddr) internal view returns (bytes32) {
+        return keccak256(
+            abi.encode(
+                keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"),
+                keccak256("PeaceBaseCoin"),
+                keccak256("1"),
+                block.chainid,
+                tokenAddr
+            )
+        );
+    }
+
+    function _buildTransferWithAuthDigest(
+        address from,
+        address to,
+        uint256 value,
+        uint256 validAfter,
+        uint256 validBefore,
+        bytes32 nonce
+    )
+        internal
+        view
+        returns (bytes32)
+    {
+        bytes32 domainSeparator = _makeDomainSeparator(address(token));
+        bytes32 structHash = keccak256(
+            abi.encode(
+                bytes32(0x7c7c6cdb67a18743f49ec6fa9b35f50d52ed05cbed4cc592e13b44501c1a2267),
+                from,
+                to,
+                value,
+                validAfter,
+                validBefore,
+                nonce
+            )
+        );
+        return keccak256(abi.encodePacked("\x19\x01", domainSeparator, structHash));
+    }
+
+    function testFeeSwapFromLocalToken() public {
+        // Setup: give community tokens to owner via swapToLocalToken
+        vm.startPrank(owner);
+        pceToken.swapToLocalToken(address(token), 100 ether);
+        vm.warp(block.timestamp + 1 days);
+        token.transfer(user1, 1 ether);
+        vm.warp(block.timestamp + 1 days);
+        vm.stopPrank();
+
+        address relayer = address(0x3);
+        uint256 displayAmount = 1 ether;
+
+        // Call swapFeeFromLocalToken directly as the community token contract
+        uint256 relayerPCEBefore = pceToken.balanceOf(relayer);
+
+        vm.prank(address(token));
+        uint256 pceAmount = pceToken.swapFeeFromLocalToken(address(token), relayer, displayAmount);
+
+        uint256 relayerPCEAfter = pceToken.balanceOf(relayer);
+        assertTrue(pceAmount > 0, "Should return non-zero PCE amount");
+        assertTrue(relayerPCEAfter > relayerPCEBefore, "Relayer should receive PCE");
+    }
+
+    function testSwapFeeFromLocalTokenOnlyCallableByCommunityToken() public {
+        // Non-community-token address should be rejected
+        vm.prank(user1);
+        vm.expectRevert("Caller must be the community token");
+        pceToken.swapFeeFromLocalToken(address(token), user1, 1 ether);
+    }
+
+    function testSwapFeeFromLocalTokenUnregisteredToken() public {
+        // Unregistered token address should be rejected
+        address fakeToken = address(0x999);
+        vm.prank(fakeToken);
+        vm.expectRevert("Token not registered");
+        pceToken.swapFeeFromLocalToken(fakeToken, user1, 1 ether);
+    }
+
+    function testFeeSwapBypassesDailyLimit() public {
+        vm.startPrank(owner);
+        pceToken.swapToLocalToken(address(token), 500 ether);
+
+        // Advance time for midnightBalance setup
+        vm.warp(block.timestamp + 1 days);
+        token.transfer(user1, 1 ether);
+        vm.warp(block.timestamp + 1 days);
+
+        // Exhaust daily swap limit via regular swaps
+        uint256 remaining = token.getRemainingSwapableToPCEBalance();
+        if (remaining > 0) {
+            pceToken.swapFromLocalToken(address(token), remaining);
+        }
+
+        // Verify regular swap now fails
+        vm.expectRevert("Exceeds daily swap limit");
+        pceToken.swapFromLocalToken(address(token), 1 ether);
+        vm.stopPrank();
+
+        // Fee swap should still work despite exhausted daily limit
+        address relayer = address(0x3);
+        uint256 relayerPCEBefore = pceToken.balanceOf(relayer);
+
+        vm.prank(address(token));
+        uint256 pceAmount = pceToken.swapFeeFromLocalToken(address(token), relayer, 0.01 ether);
+
+        assertTrue(pceAmount > 0, "Fee swap should succeed even when daily limit exhausted");
+        assertTrue(pceToken.balanceOf(relayer) > relayerPCEBefore, "Relayer should receive PCE");
+    }
+
+    function testFeeSwapDoesNotAffectDailyLimitCounters() public {
+        vm.startPrank(owner);
+        pceToken.swapToLocalToken(address(token), 100 ether);
+
+        vm.warp(block.timestamp + 1 days);
+        token.transfer(user1, 1 ether);
+        vm.warp(block.timestamp + 1 days);
+
+        uint256 globalRemainingBefore = token.getRemainingSwapableToPCEBalance();
+        vm.stopPrank();
+
+        // Do a fee swap
+        vm.prank(address(token));
+        pceToken.swapFeeFromLocalToken(address(token), address(0x3), 0.01 ether);
+
+        // Daily limit counters should be unchanged
+        uint256 globalRemainingAfter = token.getRemainingSwapableToPCEBalance();
+        assertEq(globalRemainingBefore, globalRemainingAfter, "Fee swap should not affect daily limit counters");
+    }
+
+    function testTransferWithAuthorizationFeeSwap() public {
+        // Setup: create signer with known private key
+        uint256 signerPrivateKey = 0xA11CE;
+        address signer = vm.addr(signerPrivateKey);
+        address relayer = address(0x3);
+
+        // Give signer community tokens
+        vm.startPrank(owner);
+        pceToken.swapToLocalToken(address(token), 200 ether);
+        vm.warp(block.timestamp + 1 days);
+        token.transfer(signer, 50 ether);
+        vm.warp(block.timestamp + 1 days);
+        vm.stopPrank();
+
+        // Build EIP712 signature for transferWithAuthorization
+        uint256 transferAmount = 5 ether;
+        bytes32 nonce = bytes32(uint256(1));
+        uint256 validAfter = 0;
+        uint256 validBefore = type(uint256).max;
+
+        bytes32 digest = _buildTransferWithAuthDigest(
+            signer, user2, transferAmount, validAfter, validBefore, nonce
+        );
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(signerPrivateKey, digest);
+
+        // Record balances before
+        uint256 relayerPCEBefore = pceToken.balanceOf(relayer);
+        uint256 relayerCTBefore = token.balanceOf(relayer);
+        uint256 user2CTBefore = token.balanceOf(user2);
+
+        // Execute as relayer
+        vm.prank(relayer);
+        token.transferWithAuthorization(
+            signer, user2, transferAmount, validAfter, validBefore, nonce, v, r, s
+        );
+
+        // Verify: relayer received PCE, NOT community tokens
+        uint256 relayerPCEAfter = pceToken.balanceOf(relayer);
+        uint256 relayerCTAfter = token.balanceOf(relayer);
+
+        assertTrue(relayerPCEAfter > relayerPCEBefore, "Relayer should receive PCE as fee");
+        assertEq(relayerCTAfter, relayerCTBefore, "Relayer should NOT receive community tokens");
+
+        // Verify: user2 received the transfer
+        assertTrue(token.balanceOf(user2) > user2CTBefore, "Recipient should receive community tokens");
     }
 }


### PR DESCRIPTION
## Summary
- Auto-swap meta-transaction fees from community tokens to PCE at the point of collection
- Relayers receive PCE directly instead of accumulating various community tokens
- Fee swaps are exempt from daily swap limits (both global and individual)
- New `swapFeeFromLocalToken` on PCEToken, `_collectFeeAsPCE` internal function on PCECommunityToken

## Related
- PIP Specification: https://github.com/peacecoin-protocol/PIPs/pull/8
- Tally Proposal: https://www.tally.xyz/gov/pce-dao/draft/2811459409178264786

## Changes
**PCEToken.sol:**
- `swapFeeFromLocalToken()` — swaps fee to PCE, only callable by registered community token contracts
- `FeeSwappedFromLocalToken` event
- Fee swap decreases `depositedPCEToken` (consistent with `swapFromLocalToken`)

**PCECommunityToken.sol:**
- `_collectFeeAsPCE()` — burns community token fee, calls PCEToken to send PCE to relayer
- `MetaTransactionFeeSwapped` event
- Modified: `transferWithAuthorization`, `transferFromWithAuthorization`, `setInfinityApproveFlagWithAuthorization`, `claimVoucherWithAuthorization`

**Version:** 1.0.12 → 1.0.13

## Review notes

> PIP-13 spec Notes section has been corrected: fee swaps DO decrease `depositedPCEToken`, which matches this implementation. MATIC/POL → POL also updated.

## Test plan
- [x] Direct `swapFeeFromLocalToken` unit test
- [x] Access control: only community token can call `swapFeeFromLocalToken`
- [x] Access control: unregistered token rejected
- [x] Fee swap bypasses exhausted daily swap limits
- [x] Fee swap does not affect daily limit counters
- [x] Full integration test: `transferWithAuthorization` with EIP712 signature — relayer receives PCE, not community tokens

🤖 Generated with [Claude Code](https://claude.com/claude-code)