### PR TITLE
feat: cross-chain governance via Wormhole (Phase 2)

### DIFF
--- a/script/DeployGovernanceReceiver.s.sol
+++ b/script/DeployGovernanceReceiver.s.sol
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.30;
+
+import { Script } from "forge-std/Script.sol";
+import { console } from "forge-std/console.sol";
+import { GovernanceReceiver } from "../src/governance/GovernanceReceiver.sol";
+import { TimelockController } from "@openzeppelin/contracts/governance/TimelockController.sol";
+
+/**
+ * @title DeployGovernanceReceiver
+ * @notice Deployment script for Polygon-side cross-chain governance infrastructure
+ *
+ * Deploys:
+ * - TimelockController (1 day delay, GovernanceReceiver as proposer, anyone as executor)
+ * - GovernanceReceiver (receives Wormhole messages, schedules on Timelock)
+ *
+ * Required environment variables:
+ * - PRIVATE_KEY: Private key of the deployer
+ *
+ * Optional environment variables:
+ * - WORMHOLE_RELAYER: Address of Wormhole Automatic Relayer on Polygon
+ *   (defaults to WORMHOLE_RELAYER_POLYGON if unset)
+ *
+ * Post-deployment steps:
+ * 1. Deploy GovernanceSender on Ethereum
+ * 2. Call receiver.setGovernanceSender(senderAddress) on Polygon
+ * 3. Call receiver.setEmergencyGuardian(multisigAddress) on Polygon
+ *    (MUST be done BEFORE transferring ownership to Timelock)
+ * 4. Transfer GovernanceReceiver ownership to Polygon Timelock
+ * 5. Transfer PCEToken ownership to Polygon Timelock (owner EOA tx)
+ *
+ * Usage:
+ * forge script script/DeployGovernanceReceiver.s.sol --rpc-url polygon --broadcast
+ */
+contract DeployGovernanceReceiver is Script {
+    /// @notice Polygon Timelock delay: 1 day
+    uint256 public constant TIMELOCK_DELAY = 1 days;
+
+    /// @notice Wormhole Automatic Relayer on Polygon mainnet
+    address public constant WORMHOLE_RELAYER_POLYGON = 0x27428DD2d3DD32A4D7f7C497eAaa23130d894911;
+
+    function run() external returns (address receiverAddr, address timelockAddr) {
+        uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
+        address deployer = vm.addr(deployerPrivateKey);
+
+        // Allow overriding the Wormhole Relayer address for testing
+        address wormholeRelayer = vm.envOr("WORMHOLE_RELAYER", WORMHOLE_RELAYER_POLYGON);
+
+        vm.startBroadcast(deployerPrivateKey);
+
+        // Step 1: Deploy Polygon TimelockController
+        // Empty proposers/executors — roles are granted explicitly below
+        address[] memory proposers = new address[](0);
+        address[] memory executors = new address[](0);
+
+        TimelockController timelock = new TimelockController(
+            TIMELOCK_DELAY, proposers, executors, deployer
+        );
+        timelockAddr = address(timelock);
+        console.log("Polygon TimelockController deployed at:", timelockAddr);
+
+        // Step 2: Deploy GovernanceReceiver
+        GovernanceReceiver receiver = new GovernanceReceiver(
+            wormholeRelayer, timelockAddr, deployer
+        );
+        receiverAddr = address(receiver);
+        console.log("GovernanceReceiver deployed at:", receiverAddr);
+
+        // Step 3: Grant PROPOSER_ROLE to GovernanceReceiver
+        timelock.grantRole(timelock.PROPOSER_ROLE(), receiverAddr);
+
+        // Step 4: Grant CANCELLER_ROLE to GovernanceReceiver (emergency cancellation)
+        timelock.grantRole(timelock.CANCELLER_ROLE(), receiverAddr);
+
+        // Step 5: Grant EXECUTOR_ROLE to address(0) — anyone can execute
+        timelock.grantRole(timelock.EXECUTOR_ROLE(), address(0));
+
+        // Step 6: Renounce admin role
+        timelock.renounceRole(timelock.DEFAULT_ADMIN_ROLE(), deployer);
+
+        vm.stopBroadcast();
+
+        console.log("\nDeployment Summary:");
+        console.log("===================");
+        console.log("GovernanceReceiver:", receiverAddr);
+        console.log("Polygon Timelock:", timelockAddr);
+        console.log("Timelock Delay:", TIMELOCK_DELAY, "seconds");
+        console.log("Wormhole Relayer:", wormholeRelayer);
+
+        console.log("\n  NEXT STEPS:");
+        console.log("1. Deploy GovernanceSender on Ethereum");
+        console.log("2. Call receiver.setGovernanceSender(senderAddress) on Polygon");
+        console.log("3. Call receiver.setEmergencyGuardian(multisigAddress) on Polygon");
+        console.log("4. Transfer GovernanceReceiver ownership to Polygon Timelock");
+        console.log("5. Transfer PCEToken ownership to Polygon Timelock (owner EOA tx)");
+    }
+}

--- a/script/DeployGovernanceSender.s.sol
+++ b/script/DeployGovernanceSender.s.sol
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.30;
+
+import { Script } from "forge-std/Script.sol";
+import { console } from "forge-std/console.sol";
+import { GovernanceSender } from "../src/governance/GovernanceSender.sol";
+
+/**
+ * @title DeployGovernanceSender
+ * @notice Deployment script for Ethereum-side cross-chain governance infrastructure
+ *
+ * Deploys:
+ * - GovernanceSender (sends governance proposals cross-chain via Wormhole)
+ *
+ * Required environment variables:
+ * - GOVERNANCE_RECEIVER: Address of GovernanceReceiver on Polygon
+ * - ETHEREUM_TIMELOCK: Address of Ethereum TimelockController (will become owner)
+ * - PRIVATE_KEY: Private key of the deployer
+ *
+ * Optional environment variables:
+ * - WORMHOLE_RELAYER: Address of Wormhole Relayer on Ethereum
+ *   (defaults to WORMHOLE_RELAYER_ETHEREUM if unset)
+ * - GAS_LIMIT: Gas limit for cross-chain delivery (defaults to 500_000)
+ *
+ * Post-deployment steps:
+ * 1. Call receiver.setGovernanceSender(senderAddress) on Polygon
+ * 2. Pre-fund GovernanceSender with ETH to cover Wormhole relayer fees
+ *    (sendCrossChainGovernance pays from contract balance; fund with a buffer
+ *    to absorb fee fluctuations between proposal creation and execution)
+ * 3. Ownership is transferred to Ethereum Timelock at deployment
+ *
+ * Usage:
+ * forge script script/DeployGovernanceSender.s.sol --rpc-url ethereum --broadcast
+ */
+contract DeployGovernanceSender is Script {
+    /// @notice Gas limit for cross-chain delivery on Polygon
+    uint256 public constant GAS_LIMIT = 500_000;
+
+    /// @notice Wormhole Automatic Relayer on Ethereum mainnet
+    address public constant WORMHOLE_RELAYER_ETHEREUM = 0x27428DD2d3DD32A4D7f7C497eAaa23130d894911;
+
+    function run() external returns (address senderAddr) {
+        address governanceReceiver = vm.envAddress("GOVERNANCE_RECEIVER");
+        address ethereumTimelock = vm.envAddress("ETHEREUM_TIMELOCK");
+        uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
+
+        // Allow overriding the Wormhole Relayer address for testing
+        address wormholeRelayer = vm.envOr("WORMHOLE_RELAYER", WORMHOLE_RELAYER_ETHEREUM);
+        uint256 gasLimit = vm.envOr("GAS_LIMIT", GAS_LIMIT);
+
+        vm.startBroadcast(deployerPrivateKey);
+
+        // Deploy GovernanceSender with Ethereum Timelock as owner
+        GovernanceSender sender = new GovernanceSender(
+            wormholeRelayer, governanceReceiver, gasLimit, ethereumTimelock
+        );
+        senderAddr = address(sender);
+
+        vm.stopBroadcast();
+
+        console.log("\nDeployment Summary:");
+        console.log("===================");
+        console.log("GovernanceSender:", senderAddr);
+        console.log("Owner (Ethereum Timelock):", ethereumTimelock);
+        console.log("Governance Receiver (Polygon):", governanceReceiver);
+        console.log("Gas Limit:", gasLimit);
+        console.log("Wormhole Relayer:", wormholeRelayer);
+
+        console.log("\n  NEXT STEPS:");
+        console.log("1. On Polygon: receiver.setGovernanceSender(", senderAddr, ")");
+        console.log("2. Pre-fund GovernanceSender with ETH buffer for Wormhole relayer fees");
+        console.log("3. Verify contract on Etherscan");
+        console.log("4. Test with a governance proposal");
+    }
+}

--- a/src/governance/GovernanceReceiver.sol
+++ b/src/governance/GovernanceReceiver.sol
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.30;
+
+import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
+import { TimelockController } from "@openzeppelin/contracts/governance/TimelockController.sol";
+import { IWormholeReceiver } from "./IWormholeInterfaces.sol";
+
+/**
+ * @title GovernanceReceiver
+ * @notice Polygon-side contract that receives governance proposals from Ethereum via Wormhole
+ * @dev Receives cross-chain messages from GovernanceSender and schedules them on a
+ *      local TimelockController for delayed execution.
+ *
+ * Flow: GovernanceSender (Ethereum) → Wormhole → GovernanceReceiver → Polygon Timelock → PCEToken
+ */
+contract GovernanceReceiver is IWormholeReceiver, Ownable {
+    /// @notice Wormhole chain ID for Ethereum
+    uint16 public constant SOURCE_CHAIN = 2;
+
+    /// @notice Wormhole Relayer contract on Polygon
+    address public immutable WORMHOLE_RELAYER;
+
+    /// @notice Polygon TimelockController for delayed execution
+    TimelockController public immutable TIMELOCK;
+
+    /// @notice Address of GovernanceSender on Ethereum
+    address public governanceSender;
+
+    /// @notice Emergency guardian that can cancel scheduled operations without timelock delay
+    address public emergencyGuardian;
+
+    /// @notice Tracks processed delivery hashes to prevent replay
+    mapping(bytes32 deliveryHash => bool processed) public processedDeliveries;
+
+    event CrossChainGovernanceReceived(
+        bytes32 indexed deliveryHash,
+        address[] targets,
+        uint256[] values,
+        bytes32 salt
+    );
+    event GovernanceSenderUpdated(address indexed oldSender, address indexed newSender);
+    event EmergencyGuardianUpdated(address indexed oldGuardian, address indexed newGuardian);
+
+    error UnauthorizedRelayer(address caller);
+    error InvalidSourceChain(uint16 sourceChain);
+    error InvalidSourceAddress(bytes32 sourceAddress);
+    error DeliveryAlreadyProcessed(bytes32 deliveryHash);
+    error InvalidSender();
+    error InvalidRelayer();
+    error InvalidTimelock();
+    error GovernanceSenderNotSet();
+    error NotOwnerOrGuardian();
+    error WithdrawFailed();
+
+    /**
+     * @param _wormholeRelayer Address of the Wormhole Relayer on Polygon
+     * @param _timelock Address of the Polygon TimelockController
+     * @param _owner Initial owner (deployer)
+     */
+    constructor(
+        address _wormholeRelayer,
+        address _timelock,
+        address _owner
+    ) Ownable(_owner) {
+        if (_wormholeRelayer == address(0) || _wormholeRelayer.code.length == 0) revert InvalidRelayer();
+        if (_timelock == address(0) || _timelock.code.length == 0) revert InvalidTimelock();
+
+        WORMHOLE_RELAYER = _wormholeRelayer;
+        TIMELOCK = TimelockController(payable(_timelock));
+    }
+
+    /**
+     * @notice Called by the Wormhole Relayer to deliver a cross-chain governance message
+     * @param payload Encoded governance batch (targets, values, calldatas, salt)
+     * @param sourceAddress The sender address on Ethereum (GovernanceSender, left-padded)
+     * @param sourceChain The Wormhole chain ID of the source chain (must be 2 = Ethereum)
+     * @param deliveryHash Unique hash for replay protection
+     */
+    function receiveWormholeMessages(
+        bytes memory payload,
+        bytes[] memory,
+        bytes32 sourceAddress,
+        uint16 sourceChain,
+        bytes32 deliveryHash
+    ) external payable override {
+        // Verify caller is the Wormhole Relayer
+        if (msg.sender != WORMHOLE_RELAYER) {
+            revert UnauthorizedRelayer(msg.sender);
+        }
+
+        // Verify source chain is Ethereum
+        if (sourceChain != SOURCE_CHAIN) {
+            revert InvalidSourceChain(sourceChain);
+        }
+
+        // Verify GovernanceSender has been configured
+        if (governanceSender == address(0)) {
+            revert GovernanceSenderNotSet();
+        }
+
+        // Verify source address is GovernanceSender
+        if (sourceAddress != _toBytes32(governanceSender)) {
+            revert InvalidSourceAddress(sourceAddress);
+        }
+
+        // Prevent replay
+        if (processedDeliveries[deliveryHash]) {
+            revert DeliveryAlreadyProcessed(deliveryHash);
+        }
+        processedDeliveries[deliveryHash] = true;
+
+        // Decode payload
+        (
+            address[] memory targets,
+            uint256[] memory values,
+            bytes[] memory calldatas,
+            bytes32 salt
+        ) = abi.decode(payload, (address[], uint256[], bytes[], bytes32));
+
+        // Schedule on Polygon Timelock
+        uint256 minDelay = TIMELOCK.getMinDelay();
+        TIMELOCK.scheduleBatch(targets, values, calldatas, bytes32(0), salt, minDelay);
+
+        emit CrossChainGovernanceReceived(deliveryHash, targets, values, salt);
+    }
+
+    /**
+     * @notice Cancel a scheduled batch operation on the Polygon Timelock
+     * @dev Callable by owner OR emergencyGuardian for fast cancellation without timelock delay.
+     *      Requires this contract to have CANCELLER_ROLE on the Timelock.
+     * @param id The operation identifier (from hashOperationBatch)
+     */
+    function cancelScheduledBatch(bytes32 id) external {
+        if (msg.sender != owner() && msg.sender != emergencyGuardian) {
+            revert NotOwnerOrGuardian();
+        }
+        TIMELOCK.cancel(id);
+    }
+
+    /**
+     * @notice Set the GovernanceSender address on Ethereum
+     * @param _governanceSender Address of the GovernanceSender contract
+     */
+    function setGovernanceSender(address _governanceSender) external onlyOwner {
+        if (_governanceSender == address(0)) revert InvalidSender();
+        address old = governanceSender;
+        governanceSender = _governanceSender;
+        emit GovernanceSenderUpdated(old, _governanceSender);
+    }
+
+    /**
+     * @notice Set or remove the emergency guardian address for fast cancellation
+     * @param _guardian Address of the emergency guardian (e.g., multisig), or address(0) to disable
+     */
+    function setEmergencyGuardian(address _guardian) external onlyOwner {
+        address old = emergencyGuardian;
+        emergencyGuardian = _guardian;
+        emit EmergencyGuardianUpdated(old, _guardian);
+    }
+
+    /**
+     * @notice Withdraw ETH accidentally sent to this contract
+     * @param to Recipient address
+     * @param amount Amount of ETH to withdraw
+     */
+    function withdrawETH(address payable to, uint256 amount) external onlyOwner {
+        if (to == address(0)) revert WithdrawFailed();
+        (bool success,) = to.call{ value: amount }("");
+        if (!success) revert WithdrawFailed();
+    }
+
+    /**
+     * @notice Convert an address to bytes32 (left-padded with zeros)
+     */
+    function _toBytes32(address addr) internal pure returns (bytes32) {
+        return bytes32(uint256(uint160(addr)));
+    }
+}

--- a/src/governance/GovernanceSender.sol
+++ b/src/governance/GovernanceSender.sol
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.30;
+
+import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
+import { IWormholeRelayer } from "./IWormholeInterfaces.sol";
+
+/**
+ * @title GovernanceSender
+ * @notice Ethereum-side contract that sends governance proposals cross-chain via Wormhole
+ * @dev Owned by the Ethereum TimelockController. Encodes batch operations and sends
+ *      them to GovernanceReceiver on Polygon through Wormhole Automatic Relayer.
+ *
+ * Flow: Ethereum Governor → Timelock → GovernanceSender → Wormhole → GovernanceReceiver (Polygon)
+ */
+contract GovernanceSender is Ownable {
+    /// @notice Wormhole chain ID for Polygon
+    uint16 public constant TARGET_CHAIN = 5;
+
+    /// @notice Wormhole Automatic Relayer contract
+    IWormholeRelayer public immutable WORMHOLE_RELAYER;
+
+    /// @notice Address of GovernanceReceiver on Polygon
+    address public governanceReceiver;
+
+    /// @notice Gas limit for cross-chain delivery on Polygon
+    uint256 public gasLimit;
+
+    event CrossChainGovernanceSent(
+        uint64 indexed sequence,
+        address[] targets,
+        uint256[] values,
+        bytes32 salt
+    );
+    event GovernanceReceiverUpdated(address indexed oldReceiver, address indexed newReceiver);
+    event GasLimitUpdated(uint256 oldGasLimit, uint256 newGasLimit);
+
+    error InvalidReceiver();
+    error InvalidGasLimit();
+    error ArrayLengthMismatch();
+    error EmptyProposal();
+    error InsufficientFee(uint256 required, uint256 provided);
+    error InvalidRelayer();
+    error WithdrawFailed();
+
+    /**
+     * @param _wormholeRelayer Address of the Wormhole Automatic Relayer
+     * @param _governanceReceiver Address of GovernanceReceiver on Polygon
+     * @param _gasLimit Gas limit for delivery on Polygon
+     * @param _owner Initial owner (typically the Ethereum Timelock, or a deployer EOA that later transfers ownership)
+     */
+    constructor(
+        address _wormholeRelayer,
+        address _governanceReceiver,
+        uint256 _gasLimit,
+        address _owner
+    ) Ownable(_owner) {
+        if (_wormholeRelayer == address(0) || _wormholeRelayer.code.length == 0) revert InvalidRelayer();
+        if (_governanceReceiver == address(0)) revert InvalidReceiver();
+        if (_gasLimit == 0) revert InvalidGasLimit();
+
+        WORMHOLE_RELAYER = IWormholeRelayer(_wormholeRelayer);
+        governanceReceiver = _governanceReceiver;
+        gasLimit = _gasLimit;
+    }
+
+    /**
+     * @notice Send a batch governance operation cross-chain to Polygon
+     * @dev Pays the Wormhole delivery fee from the contract's ETH balance plus any
+     *      msg.value sent with the call. This makes Timelock execution resilient to
+     *      fee changes between proposal creation and execution — pre-fund this contract
+     *      with ETH to absorb fee increases.
+     * @param targets Target contract addresses on Polygon
+     * @param values ETH values for each call (typically 0 on Polygon)
+     * @param calldatas Encoded function calls
+     * @param salt Unique salt for TimelockController scheduling
+     */
+    function sendCrossChainGovernance(
+        address[] calldata targets,
+        uint256[] calldata values,
+        bytes[] calldata calldatas,
+        bytes32 salt
+    ) external payable onlyOwner {
+        if (targets.length == 0) revert EmptyProposal();
+        if (targets.length != values.length || targets.length != calldatas.length) {
+            revert ArrayLengthMismatch();
+        }
+
+        bytes memory payload = abi.encode(targets, values, calldatas, salt);
+
+        (uint256 deliveryPrice,) = WORMHOLE_RELAYER.quoteEVMDeliveryPrice(TARGET_CHAIN, 0, gasLimit);
+        uint256 available = address(this).balance;
+        if (available < deliveryPrice) {
+            revert InsufficientFee(deliveryPrice, available);
+        }
+
+        uint64 sequence = WORMHOLE_RELAYER.sendPayloadToEvm{ value: deliveryPrice }(
+            TARGET_CHAIN,
+            governanceReceiver,
+            payload,
+            0,
+            gasLimit
+        );
+
+        emit CrossChainGovernanceSent(sequence, targets, values, salt);
+    }
+
+    /**
+     * @notice Withdraw ETH from this contract (e.g., excess pre-funded relayer fees)
+     * @param to Recipient address
+     * @param amount Amount of ETH to withdraw
+     */
+    function withdrawETH(address payable to, uint256 amount) external onlyOwner {
+        if (to == address(0)) revert WithdrawFailed();
+        (bool success,) = to.call{ value: amount }("");
+        if (!success) revert WithdrawFailed();
+    }
+
+    /// @notice Allow this contract to receive ETH for pre-funding relayer fees
+    receive() external payable {}
+
+    /**
+     * @notice Quote the delivery price for a cross-chain governance message
+     * @return nativePriceQuote Amount of native currency (ETH) required
+     */
+    function quoteDeliveryPrice() external view returns (uint256 nativePriceQuote) {
+        (nativePriceQuote,) = WORMHOLE_RELAYER.quoteEVMDeliveryPrice(TARGET_CHAIN, 0, gasLimit);
+    }
+
+    /**
+     * @notice Update the GovernanceReceiver address on Polygon
+     * @param _governanceReceiver New receiver address
+     */
+    function setGovernanceReceiver(address _governanceReceiver) external onlyOwner {
+        if (_governanceReceiver == address(0)) revert InvalidReceiver();
+        address old = governanceReceiver;
+        governanceReceiver = _governanceReceiver;
+        emit GovernanceReceiverUpdated(old, _governanceReceiver);
+    }
+
+    /**
+     * @notice Update the gas limit for cross-chain delivery
+     * @param _gasLimit New gas limit
+     */
+    function setGasLimit(uint256 _gasLimit) external onlyOwner {
+        if (_gasLimit == 0) revert InvalidGasLimit();
+        uint256 old = gasLimit;
+        gasLimit = _gasLimit;
+        emit GasLimitUpdated(old, _gasLimit);
+    }
+}

--- a/src/governance/IWormholeInterfaces.sol
+++ b/src/governance/IWormholeInterfaces.sol
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.30;
+
+/**
+ * @title IWormholeRelayer
+ * @notice Minimal interface for Wormhole Automatic Relayer (sendPayloadToEvm)
+ */
+interface IWormholeRelayer {
+    /**
+     * @notice Send a payload to an EVM chain via Wormhole
+     * @param targetChain Wormhole chain ID of the target chain
+     * @param targetAddress Address of the receiver contract on the target chain
+     * @param payload Arbitrary payload to deliver
+     * @param receiverValue msg.value to pass to the receiver on the target chain
+     * @param gasLimit Gas limit for the delivery transaction on the target chain
+     * @return sequence The sequence number of the delivery request
+     */
+    function sendPayloadToEvm(
+        uint16 targetChain,
+        address targetAddress,
+        bytes memory payload,
+        uint256 receiverValue,
+        uint256 gasLimit
+    ) external payable returns (uint64 sequence);
+
+    /**
+     * @notice Quote the delivery price for a cross-chain message
+     * @param targetChain Wormhole chain ID of the target chain
+     * @param receiverValue msg.value to pass to the receiver
+     * @param gasLimit Gas limit for the delivery transaction
+     * @return nativePriceQuote The amount of native currency required
+     * @return targetChainRefundPerGasUnused Refund per unused gas unit
+     */
+    function quoteEVMDeliveryPrice(
+        uint16 targetChain,
+        uint256 receiverValue,
+        uint256 gasLimit
+    ) external view returns (uint256 nativePriceQuote, uint256 targetChainRefundPerGasUnused);
+}
+
+/**
+ * @title IWormholeReceiver
+ * @notice Interface that must be implemented by contracts receiving Wormhole messages
+ */
+interface IWormholeReceiver {
+    /**
+     * @notice Called by the Wormhole Relayer to deliver a message
+     * @param payload The payload sent from the source chain
+     * @param additionalMessages Any additional VAAs requested (empty for simple relaying)
+     * @param sourceAddress The sender address on the source chain (left-padded to bytes32)
+     * @param sourceChain The Wormhole chain ID of the source chain
+     * @param deliveryHash Unique hash identifying this delivery
+     */
+    function receiveWormholeMessages(
+        bytes memory payload,
+        bytes[] memory additionalMessages,
+        bytes32 sourceAddress,
+        uint16 sourceChain,
+        bytes32 deliveryHash
+    ) external payable;
+}

--- a/test/CrossChainGovernance.t.sol
+++ b/test/CrossChainGovernance.t.sol
@@ -1,0 +1,321 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.30;
+
+import { Test } from "forge-std/Test.sol";
+import { GovernanceSender } from "../src/governance/GovernanceSender.sol";
+import { GovernanceReceiver } from "../src/governance/GovernanceReceiver.sol";
+import { IWormholeRelayer } from "../src/governance/IWormholeInterfaces.sol";
+import { TimelockController } from "@openzeppelin/contracts/governance/TimelockController.sol";
+import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
+import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+/**
+ * @title MockOwnableToken
+ * @notice Minimal Ownable ERC20 that mimics PCEToken's onlyOwner mint pattern
+ */
+contract MockOwnableToken is ERC20, Ownable {
+    uint256 public metaTransactionGas;
+
+    constructor() ERC20("Mock PCE", "MPCE") Ownable(msg.sender) {}
+
+    function mint(address to, uint256 amount) external onlyOwner {
+        _mint(to, amount);
+    }
+
+    function setMetaTransactionGas(uint256 _gas) external onlyOwner {
+        metaTransactionGas = _gas;
+    }
+}
+
+/**
+ * @title MockRelayerBridge
+ * @notice Simulates the Wormhole Automatic Relayer for integration testing.
+ *         Captures payloads from sendPayloadToEvm and delivers them to the receiver.
+ */
+contract MockRelayerBridge is IWormholeRelayer {
+    uint64 public nextSequence = 1;
+    uint256 public deliveryPrice = 0.01 ether;
+
+    // Captured delivery data
+    address public lastTargetAddress;
+    bytes public lastPayload;
+    bytes32 public lastSourceAddress;
+
+    function sendPayloadToEvm(
+        uint16,
+        address targetAddress,
+        bytes memory payload,
+        uint256,
+        uint256
+    ) external payable override returns (uint64 sequence) {
+        lastTargetAddress = targetAddress;
+        lastPayload = payload;
+        lastSourceAddress = bytes32(uint256(uint160(msg.sender)));
+        sequence = nextSequence++;
+    }
+
+    function quoteEVMDeliveryPrice(uint16, uint256, uint256)
+        external
+        view
+        override
+        returns (uint256 nativePriceQuote, uint256)
+    {
+        return (deliveryPrice, 0);
+    }
+
+    /**
+     * @notice Simulate Wormhole delivery by calling the receiver with captured data
+     * @param deliveryHash Unique delivery hash
+     */
+    function deliverToReceiver(bytes32 deliveryHash) external {
+        GovernanceReceiver(lastTargetAddress).receiveWormholeMessages(
+            lastPayload,
+            new bytes[](0),
+            lastSourceAddress,
+            2, // Wormhole chain ID for Ethereum (EVM chainId is 1)
+            deliveryHash
+        );
+    }
+}
+
+/**
+ * @title CrossChainGovernanceTest
+ * @notice End-to-end integration test for cross-chain governance flow.
+ *         Simulates the full flow on a single chain:
+ *         1. GovernanceSender encodes and sends via mock relayer
+ *         2. Mock relayer delivers to GovernanceReceiver
+ *         3. GovernanceReceiver schedules on Polygon Timelock
+ *         4. After delay, execute on Timelock
+ *         5. Verify token state changes
+ */
+contract CrossChainGovernanceTest is Test {
+    GovernanceSender public sender;
+    GovernanceReceiver public receiver;
+    MockRelayerBridge public relayer;
+    TimelockController public polygonTimelock;
+    MockOwnableToken public token;
+
+    address public deployer = address(this);
+    TimelockController public ethTimelock;
+    uint256 public constant POLYGON_TIMELOCK_DELAY = 1 days;
+    uint256 public constant ETH_TIMELOCK_DELAY = 2 days;
+    uint256 public constant GAS_LIMIT = 500_000;
+
+    function setUp() public {
+        // 1. Deploy mock token (simulates PCEToken's Ownable pattern)
+        token = new MockOwnableToken();
+
+        // 2. Deploy mock Wormhole relayer
+        relayer = new MockRelayerBridge();
+
+        // 3. Deploy Ethereum TimelockController (models production Governor → Timelock flow)
+        address[] memory ethProposers = new address[](1);
+        ethProposers[0] = deployer; // In production: Governor contract
+        address[] memory ethExecutors = new address[](1);
+        ethExecutors[0] = address(0); // Anyone can execute
+        ethTimelock = new TimelockController(
+            ETH_TIMELOCK_DELAY, ethProposers, ethExecutors, deployer
+        );
+
+        // 4. Deploy Polygon Timelock (empty proposers/executors, granted explicitly)
+        address[] memory proposers = new address[](0);
+        address[] memory executors = new address[](0);
+        polygonTimelock = new TimelockController(
+            POLYGON_TIMELOCK_DELAY, proposers, executors, deployer
+        );
+
+        // 5. Deploy GovernanceReceiver
+        receiver = new GovernanceReceiver(
+            address(relayer), address(polygonTimelock), deployer
+        );
+
+        // 6. Deploy GovernanceSender owned by Ethereum Timelock
+        sender = new GovernanceSender(
+            address(relayer), address(receiver), GAS_LIMIT, address(ethTimelock)
+        );
+
+        // 7. Configure: set sender on receiver
+        receiver.setGovernanceSender(address(sender));
+
+        // 8. Grant PROPOSER_ROLE to receiver on Polygon Timelock
+        polygonTimelock.grantRole(polygonTimelock.PROPOSER_ROLE(), address(receiver));
+
+        // 8b. Grant CANCELLER_ROLE to receiver (matches deploy script)
+        polygonTimelock.grantRole(polygonTimelock.CANCELLER_ROLE(), address(receiver));
+
+        // 8c. Grant EXECUTOR_ROLE to anyone
+        polygonTimelock.grantRole(polygonTimelock.EXECUTOR_ROLE(), address(0));
+
+        // 9. Transfer token ownership to Polygon Timelock
+        token.transferOwnership(address(polygonTimelock));
+
+        // 10. Renounce Timelock admin
+        polygonTimelock.renounceRole(polygonTimelock.DEFAULT_ADMIN_ROLE(), deployer);
+
+        // 11. Fund Ethereum Timelock with ETH for relayer fees
+        vm.deal(address(ethTimelock), 10 ether);
+    }
+
+    /// @dev Helper: schedule + wait + execute on Ethereum Timelock to call GovernanceSender
+    function _executeViaEthTimelock(
+        address[] memory targets,
+        uint256[] memory values,
+        bytes[] memory calldatas,
+        bytes32 salt
+    ) internal {
+        // Encode the call to GovernanceSender.sendCrossChainGovernance
+        uint256 fee = sender.quoteDeliveryPrice();
+        address[] memory ethTargets = new address[](1);
+        ethTargets[0] = address(sender);
+        uint256[] memory ethValues = new uint256[](1);
+        ethValues[0] = fee;
+        bytes[] memory ethCalldatas = new bytes[](1);
+        ethCalldatas[0] = abi.encodeWithSelector(
+            sender.sendCrossChainGovernance.selector, targets, values, calldatas, salt
+        );
+
+        // Schedule on Ethereum Timelock (deployer has PROPOSER_ROLE)
+        ethTimelock.scheduleBatch(ethTargets, ethValues, ethCalldatas, bytes32(0), salt, ETH_TIMELOCK_DELAY);
+
+        // Wait for Ethereum Timelock delay
+        vm.warp(block.timestamp + ETH_TIMELOCK_DELAY + 1);
+
+        // Execute on Ethereum Timelock (anyone can execute)
+        ethTimelock.executeBatch(ethTargets, ethValues, ethCalldatas, bytes32(0), salt);
+    }
+
+    function testFullCrossChainMint() public {
+        // === Step 1: Prepare governance proposal (mint tokens) ===
+        address mintRecipient = address(0xABCD);
+        uint256 mintAmount = 1000 ether;
+
+        address[] memory targets = new address[](1);
+        targets[0] = address(token);
+        uint256[] memory values = new uint256[](1);
+        bytes[] memory calldatas = new bytes[](1);
+        calldatas[0] = abi.encodeWithSignature(
+            "mint(address,uint256)", mintRecipient, mintAmount
+        );
+        bytes32 salt = keccak256("cross-chain-mint-1");
+
+        // === Step 2: Execute via Ethereum Timelock → GovernanceSender → Wormhole ===
+        _executeViaEthTimelock(targets, values, calldatas, salt);
+
+        // === Step 3: Wormhole delivers to Polygon ===
+        bytes32 deliveryHash = keccak256("delivery-mint-1");
+        relayer.deliverToReceiver(deliveryHash);
+
+        // === Step 4: Verify operation is pending on Polygon Timelock ===
+        bytes32 timelockId = polygonTimelock.hashOperationBatch(
+            targets, values, calldatas, bytes32(0), salt
+        );
+        assertTrue(polygonTimelock.isOperationPending(timelockId));
+        assertFalse(polygonTimelock.isOperationReady(timelockId));
+
+        // === Step 5: Wait for Polygon timelock delay ===
+        vm.warp(block.timestamp + POLYGON_TIMELOCK_DELAY + 1);
+        assertTrue(polygonTimelock.isOperationReady(timelockId));
+
+        // === Step 6: Execute on Polygon Timelock ===
+        polygonTimelock.executeBatch(targets, values, calldatas, bytes32(0), salt);
+        assertTrue(polygonTimelock.isOperationDone(timelockId));
+
+        // === Step 7: Verify token state ===
+        assertEq(token.balanceOf(mintRecipient), mintAmount);
+    }
+
+    function testFullCrossChainBatchOperations() public {
+        // Batch: mint + setMetaTransactionGas
+        address mintRecipient = address(0xABCD);
+        uint256 mintAmount = 500 ether;
+        uint256 newGas = 80000;
+
+        address[] memory targets = new address[](2);
+        targets[0] = address(token);
+        targets[1] = address(token);
+        uint256[] memory values = new uint256[](2);
+        bytes[] memory calldatas = new bytes[](2);
+        calldatas[0] = abi.encodeWithSignature(
+            "mint(address,uint256)", mintRecipient, mintAmount
+        );
+        calldatas[1] = abi.encodeWithSignature("setMetaTransactionGas(uint256)", newGas);
+        bytes32 salt = keccak256("cross-chain-batch-1");
+
+        // Execute via Ethereum Timelock
+        _executeViaEthTimelock(targets, values, calldatas, salt);
+
+        // Deliver
+        bytes32 deliveryHash = keccak256("delivery-batch-1");
+        relayer.deliverToReceiver(deliveryHash);
+
+        // Wait for Polygon delay and execute
+        vm.warp(block.timestamp + POLYGON_TIMELOCK_DELAY + 1);
+        polygonTimelock.executeBatch(targets, values, calldatas, bytes32(0), salt);
+
+        // Verify both operations succeeded
+        assertEq(token.balanceOf(mintRecipient), mintAmount);
+        assertEq(token.metaTransactionGas(), newGas);
+    }
+
+    function testCannotExecuteBeforeDelay() public {
+        address[] memory targets = new address[](1);
+        targets[0] = address(token);
+        uint256[] memory values = new uint256[](1);
+        bytes[] memory calldatas = new bytes[](1);
+        calldatas[0] = abi.encodeWithSignature(
+            "mint(address,uint256)", address(0xABCD), 100 ether
+        );
+        bytes32 salt = keccak256("too-early");
+
+        // Execute via Ethereum Timelock and deliver
+        _executeViaEthTimelock(targets, values, calldatas, salt);
+
+        bytes32 deliveryHash = keccak256("delivery-too-early");
+        relayer.deliverToReceiver(deliveryHash);
+
+        // Try to execute on Polygon before delay — should revert
+        vm.expectRevert();
+        polygonTimelock.executeBatch(targets, values, calldatas, bytes32(0), salt);
+    }
+
+    function testReplayProtection() public {
+        address[] memory targets = new address[](1);
+        targets[0] = address(token);
+        uint256[] memory values = new uint256[](1);
+        bytes[] memory calldatas = new bytes[](1);
+        calldatas[0] = abi.encodeWithSignature(
+            "mint(address,uint256)", address(0xABCD), 100 ether
+        );
+        bytes32 salt = keccak256("replay-test");
+
+        // Execute via Ethereum Timelock and deliver
+        _executeViaEthTimelock(targets, values, calldatas, salt);
+
+        bytes32 deliveryHash = keccak256("delivery-replay-test");
+        relayer.deliverToReceiver(deliveryHash);
+
+        // Second delivery with same hash should fail (simulate re-delivery by relayer)
+        vm.prank(address(relayer));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                GovernanceReceiver.DeliveryAlreadyProcessed.selector, deliveryHash
+            )
+        );
+        relayer.deliverToReceiver(deliveryHash);
+    }
+
+    function testOnlyEthTimelockCanSend() public {
+        address[] memory targets = new address[](1);
+        targets[0] = address(token);
+        uint256[] memory values = new uint256[](1);
+        bytes[] memory calldatas = new bytes[](1);
+        calldatas[0] = hex"";
+
+        vm.deal(address(0xDEAD), 1 ether);
+        vm.prank(address(0xDEAD));
+        vm.expectRevert();
+        sender.sendCrossChainGovernance{ value: 0.01 ether }(
+            targets, values, calldatas, bytes32(0)
+        );
+    }
+}

--- a/test/GovernanceReceiver.t.sol
+++ b/test/GovernanceReceiver.t.sol
@@ -1,0 +1,280 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.30;
+
+import { Test } from "forge-std/Test.sol";
+import { GovernanceReceiver } from "../src/governance/GovernanceReceiver.sol";
+import { TimelockController } from "@openzeppelin/contracts/governance/TimelockController.sol";
+
+contract GovernanceReceiverTest is Test {
+    GovernanceReceiver public receiver;
+    TimelockController public timelock;
+
+    address public owner = address(this);
+    address public wormholeRelayer = address(0xEE01);
+    address public governanceSender = address(0x5EED);
+
+    uint256 public constant TIMELOCK_DELAY = 1 days;
+
+    function setUp() public {
+        // Etch code at mock addresses so code.length > 0 checks pass
+        vm.etch(wormholeRelayer, hex"00");
+        vm.etch(governanceSender, hex"00");
+
+        // Deploy TimelockController with empty proposers/executors
+        address[] memory proposers = new address[](0);
+        address[] memory executors = new address[](0);
+
+        timelock = new TimelockController(TIMELOCK_DELAY, proposers, executors, owner);
+
+        // Deploy GovernanceReceiver
+        receiver = new GovernanceReceiver(wormholeRelayer, address(timelock), owner);
+
+        // Set governance sender
+        receiver.setGovernanceSender(governanceSender);
+
+        // Grant PROPOSER_ROLE to receiver
+        timelock.grantRole(timelock.PROPOSER_ROLE(), address(receiver));
+
+        // Grant CANCELLER_ROLE to receiver (matches deploy script)
+        timelock.grantRole(timelock.CANCELLER_ROLE(), address(receiver));
+
+        // Grant EXECUTOR_ROLE to anyone
+        timelock.grantRole(timelock.EXECUTOR_ROLE(), address(0));
+
+        // Renounce admin role
+        timelock.renounceRole(timelock.DEFAULT_ADMIN_ROLE(), owner);
+    }
+
+    function testConstructor() public view {
+        assertEq(receiver.WORMHOLE_RELAYER(), wormholeRelayer);
+        assertEq(address(receiver.TIMELOCK()), address(timelock));
+        assertEq(receiver.owner(), owner);
+        assertEq(receiver.SOURCE_CHAIN(), 2);
+    }
+
+    function testSetGovernanceSender() public {
+        GovernanceReceiver newReceiver = new GovernanceReceiver(
+            wormholeRelayer, address(timelock), owner
+        );
+        address newSender = address(0xBEEF);
+        newReceiver.setGovernanceSender(newSender);
+        assertEq(newReceiver.governanceSender(), newSender);
+    }
+
+    function testSetGovernanceSenderRevertsInvalid() public {
+        vm.expectRevert(GovernanceReceiver.InvalidSender.selector);
+        receiver.setGovernanceSender(address(0));
+    }
+
+    function testSetGovernanceSenderRevertsOnlyOwner() public {
+        vm.prank(address(0xDEAD));
+        vm.expectRevert();
+        receiver.setGovernanceSender(address(0xBEEF));
+    }
+
+    function testReceiveWormholeMessages() public {
+        address[] memory targets = new address[](1);
+        targets[0] = address(0x1234);
+        uint256[] memory values = new uint256[](1);
+        bytes[] memory calldatas = new bytes[](1);
+        calldatas[0] = abi.encodeWithSignature("mint(address,uint256)", address(0x5678), 100 ether);
+        bytes32 salt = keccak256("test-salt");
+
+        bytes memory payload = abi.encode(targets, values, calldatas, salt);
+        bytes32 sourceAddress = bytes32(uint256(uint160(governanceSender)));
+        bytes32 deliveryHash = keccak256("delivery-1");
+
+        // Call from wormhole relayer
+        vm.prank(wormholeRelayer);
+        receiver.receiveWormholeMessages(payload, new bytes[](0), sourceAddress, 2, deliveryHash);
+
+        // Verify delivery was processed
+        assertTrue(receiver.processedDeliveries(deliveryHash));
+
+        // Verify operation was scheduled on timelock
+        bytes32 timelockId = timelock.hashOperationBatch(
+            targets, values, calldatas, bytes32(0), salt
+        );
+        assertTrue(timelock.isOperationPending(timelockId));
+    }
+
+    function testReceiveRevertsUnauthorizedRelayer() public {
+        bytes memory payload = hex"";
+        bytes32 sourceAddress = bytes32(uint256(uint160(governanceSender)));
+
+        vm.prank(address(0xDEAD));
+        vm.expectRevert(
+            abi.encodeWithSelector(GovernanceReceiver.UnauthorizedRelayer.selector, address(0xDEAD))
+        );
+        receiver.receiveWormholeMessages(payload, new bytes[](0), sourceAddress, 2, bytes32(0));
+    }
+
+    function testReceiveRevertsInvalidSourceChain() public {
+        bytes memory payload = hex"";
+        bytes32 sourceAddress = bytes32(uint256(uint160(governanceSender)));
+
+        vm.prank(wormholeRelayer);
+        vm.expectRevert(
+            abi.encodeWithSelector(GovernanceReceiver.InvalidSourceChain.selector, uint16(4))
+        );
+        receiver.receiveWormholeMessages(payload, new bytes[](0), sourceAddress, 4, bytes32(0));
+    }
+
+    function testReceiveRevertsInvalidSourceAddress() public {
+        bytes memory payload = hex"";
+        bytes32 wrongAddress = bytes32(uint256(uint160(address(0xDEAD))));
+
+        vm.prank(wormholeRelayer);
+        vm.expectRevert(
+            abi.encodeWithSelector(GovernanceReceiver.InvalidSourceAddress.selector, wrongAddress)
+        );
+        receiver.receiveWormholeMessages(payload, new bytes[](0), wrongAddress, 2, bytes32(0));
+    }
+
+    function testReceiveRevertsReplayAttack() public {
+        address[] memory targets = new address[](1);
+        targets[0] = address(0x1234);
+        uint256[] memory values = new uint256[](1);
+        bytes[] memory calldatas = new bytes[](1);
+        calldatas[0] = hex"";
+        bytes32 salt = keccak256("replay-salt");
+
+        bytes memory payload = abi.encode(targets, values, calldatas, salt);
+        bytes32 sourceAddress = bytes32(uint256(uint160(governanceSender)));
+        bytes32 deliveryHash = keccak256("delivery-replay");
+
+        // First delivery succeeds
+        vm.prank(wormholeRelayer);
+        receiver.receiveWormholeMessages(payload, new bytes[](0), sourceAddress, 2, deliveryHash);
+
+        // Second delivery with same hash reverts
+        vm.prank(wormholeRelayer);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                GovernanceReceiver.DeliveryAlreadyProcessed.selector, deliveryHash
+            )
+        );
+        receiver.receiveWormholeMessages(payload, new bytes[](0), sourceAddress, 2, deliveryHash);
+    }
+
+    function testReceiveRevertsGovernanceSenderNotSet() public {
+        GovernanceReceiver freshReceiver = new GovernanceReceiver(
+            wormholeRelayer, address(timelock), owner
+        );
+        // governanceSender not set (default address(0))
+        bytes32 sourceAddress = bytes32(uint256(uint160(governanceSender)));
+        vm.prank(wormholeRelayer);
+        vm.expectRevert(GovernanceReceiver.GovernanceSenderNotSet.selector);
+        freshReceiver.receiveWormholeMessages(hex"", new bytes[](0), sourceAddress, 2, bytes32(0));
+    }
+
+    function testCancelScheduledBatchByOwner() public {
+        // Schedule an operation via receiveWormholeMessages
+        address[] memory targets = new address[](1);
+        targets[0] = address(0x1234);
+        uint256[] memory values = new uint256[](1);
+        bytes[] memory calldatas = new bytes[](1);
+        calldatas[0] = hex"";
+        bytes32 salt = keccak256("cancel-salt");
+
+        bytes memory payload = abi.encode(targets, values, calldatas, salt);
+        bytes32 sourceAddress = bytes32(uint256(uint160(governanceSender)));
+
+        vm.prank(wormholeRelayer);
+        receiver.receiveWormholeMessages(payload, new bytes[](0), sourceAddress, 2, keccak256("d-cancel"));
+
+        bytes32 timelockId = timelock.hashOperationBatch(targets, values, calldatas, bytes32(0), salt);
+        assertTrue(timelock.isOperationPending(timelockId));
+
+        // Owner cancels
+        receiver.cancelScheduledBatch(timelockId);
+        assertFalse(timelock.isOperationPending(timelockId));
+    }
+
+    function testCancelScheduledBatchByGuardian() public {
+        address guardian = address(0xAAAA);
+        receiver.setEmergencyGuardian(guardian);
+
+        // Schedule an operation
+        address[] memory targets = new address[](1);
+        targets[0] = address(0x1234);
+        uint256[] memory values = new uint256[](1);
+        bytes[] memory calldatas = new bytes[](1);
+        calldatas[0] = hex"";
+        bytes32 salt = keccak256("guardian-cancel-salt");
+
+        bytes memory payload = abi.encode(targets, values, calldatas, salt);
+        bytes32 sourceAddress = bytes32(uint256(uint160(governanceSender)));
+
+        vm.prank(wormholeRelayer);
+        receiver.receiveWormholeMessages(payload, new bytes[](0), sourceAddress, 2, keccak256("d-guardian"));
+
+        bytes32 timelockId = timelock.hashOperationBatch(targets, values, calldatas, bytes32(0), salt);
+
+        // Guardian cancels
+        vm.prank(guardian);
+        receiver.cancelScheduledBatch(timelockId);
+        assertFalse(timelock.isOperationPending(timelockId));
+    }
+
+    function testCancelScheduledBatchRevertsUnauthorized() public {
+        vm.prank(address(0xDEAD));
+        vm.expectRevert(GovernanceReceiver.NotOwnerOrGuardian.selector);
+        receiver.cancelScheduledBatch(bytes32(0));
+    }
+
+    function testSetEmergencyGuardian() public {
+        address guardian = address(0xBBBB);
+        receiver.setEmergencyGuardian(guardian);
+        assertEq(receiver.emergencyGuardian(), guardian);
+    }
+
+    function testSetEmergencyGuardianToZeroDisables() public {
+        receiver.setEmergencyGuardian(address(0xBBBB));
+        receiver.setEmergencyGuardian(address(0));
+        assertEq(receiver.emergencyGuardian(), address(0));
+    }
+
+    function testSetEmergencyGuardianRevertsOnlyOwner() public {
+        vm.prank(address(0xDEAD));
+        vm.expectRevert();
+        receiver.setEmergencyGuardian(address(0xBBBB));
+    }
+
+    function testReceiveEmitsEvent() public {
+        address[] memory targets = new address[](1);
+        targets[0] = address(0x1234);
+        uint256[] memory values = new uint256[](1);
+        bytes[] memory calldatas = new bytes[](1);
+        calldatas[0] = hex"";
+        bytes32 salt = keccak256("event-salt");
+
+        bytes memory payload = abi.encode(targets, values, calldatas, salt);
+        bytes32 sourceAddress = bytes32(uint256(uint160(governanceSender)));
+        bytes32 deliveryHash = keccak256("delivery-event");
+
+        vm.prank(wormholeRelayer);
+        vm.expectEmit(true, false, false, true);
+        emit GovernanceReceiver.CrossChainGovernanceReceived(deliveryHash, targets, values, salt);
+        receiver.receiveWormholeMessages(payload, new bytes[](0), sourceAddress, 2, deliveryHash);
+    }
+
+    function testWithdrawETH() public {
+        // Fund the receiver
+        vm.deal(address(receiver), 1 ether);
+        assertEq(address(receiver).balance, 1 ether);
+
+        // Owner withdraws
+        address payable recipient = payable(address(0xCAFE));
+        receiver.withdrawETH(recipient, 0.5 ether);
+        assertEq(recipient.balance, 0.5 ether);
+        assertEq(address(receiver).balance, 0.5 ether);
+    }
+
+    function testWithdrawETHRevertsOnlyOwner() public {
+        vm.deal(address(receiver), 1 ether);
+        vm.prank(address(0xDEAD));
+        vm.expectRevert();
+        receiver.withdrawETH(payable(address(0xCAFE)), 0.5 ether);
+    }
+}

--- a/test/GovernanceSender.t.sol
+++ b/test/GovernanceSender.t.sol
@@ -1,0 +1,259 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.30;
+
+import { Test } from "forge-std/Test.sol";
+import { GovernanceSender } from "../src/governance/GovernanceSender.sol";
+import { IWormholeRelayer } from "../src/governance/IWormholeInterfaces.sol";
+
+contract MockWormholeRelayer is IWormholeRelayer {
+    uint64 public nextSequence = 1;
+    uint256 public deliveryPrice = 0.01 ether;
+
+    bytes public lastPayload;
+    uint16 public lastTargetChain;
+    address public lastTargetAddress;
+    uint256 public lastReceiverValue;
+    uint256 public lastGasLimit;
+
+    function sendPayloadToEvm(
+        uint16 targetChain,
+        address targetAddress,
+        bytes memory payload,
+        uint256 receiverValue,
+        uint256 gasLimit
+    ) external payable override returns (uint64 sequence) {
+        lastTargetChain = targetChain;
+        lastTargetAddress = targetAddress;
+        lastPayload = payload;
+        lastReceiverValue = receiverValue;
+        lastGasLimit = gasLimit;
+        sequence = nextSequence++;
+    }
+
+    function quoteEVMDeliveryPrice(uint16, uint256, uint256)
+        external
+        view
+        override
+        returns (uint256 nativePriceQuote, uint256 targetChainRefundPerGasUnused)
+    {
+        return (deliveryPrice, 0);
+    }
+
+    function setDeliveryPrice(uint256 _price) external {
+        deliveryPrice = _price;
+    }
+}
+
+contract GovernanceSenderTest is Test {
+    GovernanceSender public sender;
+    MockWormholeRelayer public relayer;
+
+    address public owner = address(this);
+    address public receiver = address(0xBEEF);
+    uint256 public constant GAS_LIMIT = 500_000;
+
+    function setUp() public {
+        relayer = new MockWormholeRelayer();
+        sender = new GovernanceSender(
+            address(relayer),
+            receiver,
+            GAS_LIMIT,
+            owner
+        );
+    }
+
+    function testConstructor() public view {
+        assertEq(address(sender.WORMHOLE_RELAYER()), address(relayer));
+        assertEq(sender.governanceReceiver(), receiver);
+        assertEq(sender.gasLimit(), GAS_LIMIT);
+        assertEq(sender.owner(), owner);
+        assertEq(sender.TARGET_CHAIN(), 5);
+    }
+
+    function testConstructorRevertsInvalidRelayer() public {
+        vm.expectRevert(GovernanceSender.InvalidRelayer.selector);
+        new GovernanceSender(address(0), receiver, GAS_LIMIT, owner);
+    }
+
+    function testConstructorRevertsInvalidReceiver() public {
+        vm.expectRevert(GovernanceSender.InvalidReceiver.selector);
+        new GovernanceSender(address(relayer), address(0), GAS_LIMIT, owner);
+    }
+
+    function testConstructorRevertsInvalidGasLimit() public {
+        vm.expectRevert(GovernanceSender.InvalidGasLimit.selector);
+        new GovernanceSender(address(relayer), receiver, 0, owner);
+    }
+
+    function testSendCrossChainGovernance() public {
+        address[] memory targets = new address[](1);
+        targets[0] = address(0x1234);
+        uint256[] memory values = new uint256[](1);
+        values[0] = 0;
+        bytes[] memory calldatas = new bytes[](1);
+        calldatas[0] = abi.encodeWithSignature("mint(address,uint256)", address(0x5678), 100 ether);
+        bytes32 salt = keccak256("test-salt");
+
+        uint256 fee = sender.quoteDeliveryPrice();
+        sender.sendCrossChainGovernance{ value: fee }(targets, values, calldatas, salt);
+
+        // Verify relayer was called correctly
+        assertEq(relayer.lastTargetChain(), 5);
+        assertEq(relayer.lastTargetAddress(), receiver);
+        assertEq(relayer.lastReceiverValue(), 0);
+        assertEq(relayer.lastGasLimit(), GAS_LIMIT);
+
+        // Verify payload encoding
+        (
+            address[] memory decodedTargets,
+            uint256[] memory decodedValues,
+            bytes[] memory decodedCalldatas,
+            bytes32 decodedSalt
+        ) = abi.decode(relayer.lastPayload(), (address[], uint256[], bytes[], bytes32));
+        assertEq(decodedTargets[0], targets[0]);
+        assertEq(decodedValues[0], values[0]);
+        assertEq(decodedCalldatas[0], calldatas[0]);
+        assertEq(decodedSalt, salt);
+    }
+
+    function testSendCrossChainGovernanceBatch() public {
+        address[] memory targets = new address[](2);
+        targets[0] = address(0x1234);
+        targets[1] = address(0x5678);
+        uint256[] memory values = new uint256[](2);
+        bytes[] memory calldatas = new bytes[](2);
+        calldatas[0] = abi.encodeWithSignature("mint(address,uint256)", address(0xABCD), 100 ether);
+        calldatas[1] = abi.encodeWithSignature("setMetaTransactionGas(uint256)", 50000);
+        bytes32 salt = keccak256("batch-salt");
+
+        uint256 fee = sender.quoteDeliveryPrice();
+        sender.sendCrossChainGovernance{ value: fee }(targets, values, calldatas, salt);
+
+        assertEq(relayer.lastTargetChain(), 5);
+    }
+
+    function testSendRevertsOnlyOwner() public {
+        address[] memory targets = new address[](1);
+        targets[0] = address(0x1234);
+        uint256[] memory values = new uint256[](1);
+        bytes[] memory calldatas = new bytes[](1);
+        calldatas[0] = hex"";
+        bytes32 salt = keccak256("salt");
+
+        address unauthorized = address(0xDEAD);
+        vm.deal(unauthorized, 1 ether);
+        vm.prank(unauthorized);
+        vm.expectRevert();
+        sender.sendCrossChainGovernance{ value: 0.01 ether }(targets, values, calldatas, salt);
+    }
+
+    function testSendRevertsEmptyProposal() public {
+        address[] memory targets = new address[](0);
+        uint256[] memory values = new uint256[](0);
+        bytes[] memory calldatas = new bytes[](0);
+
+        vm.expectRevert(GovernanceSender.EmptyProposal.selector);
+        sender.sendCrossChainGovernance(targets, values, calldatas, bytes32(0));
+    }
+
+    function testSendRevertsArrayLengthMismatch() public {
+        address[] memory targets = new address[](2);
+        uint256[] memory values = new uint256[](1);
+        bytes[] memory calldatas = new bytes[](2);
+
+        vm.expectRevert(GovernanceSender.ArrayLengthMismatch.selector);
+        sender.sendCrossChainGovernance(targets, values, calldatas, bytes32(0));
+    }
+
+    function testSendRevertsInsufficientFee() public {
+        address[] memory targets = new address[](1);
+        targets[0] = address(0x1234);
+        uint256[] memory values = new uint256[](1);
+        bytes[] memory calldatas = new bytes[](1);
+        calldatas[0] = hex"";
+
+        vm.expectRevert(
+            abi.encodeWithSelector(GovernanceSender.InsufficientFee.selector, 0.01 ether, 0)
+        );
+        sender.sendCrossChainGovernance{ value: 0 }(targets, values, calldatas, bytes32(0));
+    }
+
+    function testQuoteDeliveryPrice() public view {
+        uint256 price = sender.quoteDeliveryPrice();
+        assertEq(price, 0.01 ether);
+    }
+
+    function testSetGovernanceReceiver() public {
+        address newReceiver = address(0xCAFE);
+        sender.setGovernanceReceiver(newReceiver);
+        assertEq(sender.governanceReceiver(), newReceiver);
+    }
+
+    function testSetGovernanceReceiverRevertsInvalid() public {
+        vm.expectRevert(GovernanceSender.InvalidReceiver.selector);
+        sender.setGovernanceReceiver(address(0));
+    }
+
+    function testSetGovernanceReceiverRevertsOnlyOwner() public {
+        vm.prank(address(0xDEAD));
+        vm.expectRevert();
+        sender.setGovernanceReceiver(address(0xCAFE));
+    }
+
+    function testSetGasLimit() public {
+        sender.setGasLimit(1_000_000);
+        assertEq(sender.gasLimit(), 1_000_000);
+    }
+
+    function testSetGasLimitRevertsInvalid() public {
+        vm.expectRevert(GovernanceSender.InvalidGasLimit.selector);
+        sender.setGasLimit(0);
+    }
+
+    function testSetGasLimitRevertsOnlyOwner() public {
+        vm.prank(address(0xDEAD));
+        vm.expectRevert();
+        sender.setGasLimit(1_000_000);
+    }
+
+    function testEmitsCrossChainGovernanceSent() public {
+        address[] memory targets = new address[](1);
+        targets[0] = address(0x1234);
+        uint256[] memory values = new uint256[](1);
+        bytes[] memory calldatas = new bytes[](1);
+        calldatas[0] = hex"";
+        bytes32 salt = keccak256("event-salt");
+
+        uint256 fee = sender.quoteDeliveryPrice();
+
+        vm.expectEmit(true, false, false, true);
+        emit GovernanceSender.CrossChainGovernanceSent(1, targets, values, salt);
+
+        sender.sendCrossChainGovernance{ value: fee }(targets, values, calldatas, salt);
+    }
+
+    function testWithdrawETH() public {
+        // Pre-fund the sender
+        vm.deal(address(sender), 1 ether);
+        assertEq(address(sender).balance, 1 ether);
+
+        address payable recipient = payable(address(0xCAFE));
+        sender.withdrawETH(recipient, 0.5 ether);
+        assertEq(recipient.balance, 0.5 ether);
+        assertEq(address(sender).balance, 0.5 ether);
+    }
+
+    function testWithdrawETHRevertsOnlyOwner() public {
+        vm.deal(address(sender), 1 ether);
+        vm.prank(address(0xDEAD));
+        vm.expectRevert();
+        sender.withdrawETH(payable(address(0xCAFE)), 0.5 ether);
+    }
+
+    function testReceiveETH() public {
+        vm.deal(address(this), 1 ether);
+        (bool success,) = address(sender).call{ value: 1 ether }("");
+        assertTrue(success);
+        assertEq(address(sender).balance, 1 ether);
+    }
+}


### PR DESCRIPTION
## Summary

- Implement cross-chain governance relay from Ethereum to Polygon via Wormhole Automatic Relayer
- `GovernanceSender` (Ethereum): Called by Timelock, encodes batch operations and sends via Wormhole
- `GovernanceReceiver` (Polygon): Receives Wormhole messages, validates source chain/address/replay, schedules on Polygon TimelockController
- Deploy scripts for both Polygon (Receiver + Timelock) and Ethereum (Sender)

**Flow:**
```
Ethereum Governor → Timelock(2d) → GovernanceSender
    → Wormhole Automatic Relayer →
        GovernanceReceiver → Polygon Timelock(1d) → PCEToken
```

## New files

| File | Description |
|------|-------------|
| `src/governance/IWormholeInterfaces.sol` | Minimal Wormhole Relayer/Receiver interfaces |
| `src/governance/GovernanceSender.sol` | Ethereum: Timelock → Wormhole send |
| `src/governance/GovernanceReceiver.sol` | Polygon: Wormhole receive → Timelock schedule |
| `script/DeployGovernanceReceiver.s.sol` | Polygon: Receiver + TimelockController deploy |
| `script/DeployGovernanceSender.s.sol` | Ethereum: Sender deploy |
| `test/GovernanceSender.t.sol` | Sender unit tests (21 tests) |
| `test/GovernanceReceiver.t.sol` | Receiver unit tests (19 tests) |
| `test/CrossChainGovernance.t.sol` | E2E integration tests (5 tests) |

## Wormhole relay fee management

GovernanceSender pays Wormhole relay fees from its own ETH balance. Fee management strategy:

- **Manual top-up**: Pre-fund GovernanceSender with ETH (e.g., 0.1 ETH covers hundreds of proposals)
- Monitor balance periodically; top up when low
- `withdrawETH()` available for reclaiming excess funds
- Fallback: `sendCrossChainGovernance` is `payable`, so Timelock proposals can also include `value` to cover fees per-execution

## Test plan

- [x] `forge build` — compiles with no warnings
- [x] `forge test` — all 70 tests pass
- [ ] Deploy to testnet
- [ ] Cross-chain delivery test via Wormhole testnet

---

<details>
<summary>日本語訳</summary>

## 概要

- Wormhole Automatic Relayer を使用した Ethereum から Polygon へのクロスチェーンガバナンスリレーの実装
- `GovernanceSender` (Ethereum): Timelock から呼び出され、バッチ操作をエンコードして Wormhole 経由で送信
- `GovernanceReceiver` (Polygon): Wormhole メッセージを受信し、ソースチェーン・アドレス・リプレイを検証後、Polygon TimelockController にスケジュール
- デプロイスクリプト: Polygon (Receiver + Timelock) と Ethereum (Sender) の両方

**フロー:**
```
Ethereum Governor → Timelock(2日) → GovernanceSender
    → Wormhole Automatic Relayer →
        GovernanceReceiver → Polygon Timelock(1日) → PCEToken
```

## 新規ファイル

| ファイル | 説明 |
|---------|------|
| `src/governance/IWormholeInterfaces.sol` | Wormhole Relayer/Receiver の最小インターフェース定義 |
| `src/governance/GovernanceSender.sol` | Ethereum側: Timelock → Wormhole 送信 |
| `src/governance/GovernanceReceiver.sol` | Polygon側: Wormhole 受信 → Timelock スケジュール |
| `script/DeployGovernanceReceiver.s.sol` | Polygon側: Receiver + TimelockController のデプロイ |
| `script/DeployGovernanceSender.s.sol` | Ethereum側: Sender のデプロイ |
| `test/GovernanceSender.t.sol` | Sender 単体テスト (21テスト) |
| `test/GovernanceReceiver.t.sol` | Receiver 単体テスト (19テスト) |
| `test/CrossChainGovernance.t.sol` | E2E統合テスト (5テスト) |

## Wormhole リレー手数料の管理

GovernanceSender は自身の ETH 残高から Wormhole リレー手数料を支払います。手数料管理戦略:

- **手動補充**: GovernanceSender に事前に ETH を入金する（例: 0.1 ETH で数百回の提案をカバー可能）
- 残高を定期的に監視し、少なくなったら補充する
- `withdrawETH()` で余剰資金の回収が可能
- フォールバック: `sendCrossChainGovernance` は `payable` であるため、Timelock の提案に `value` を含めて実行ごとに手数料を渡すことも可能

## テスト計画

- [x] `forge build` — 警告なしでコンパイル成功
- [x] `forge test` — 全70テスト通過
- [ ] テストネットへのデプロイ
- [ ] Wormhole テストネットでのクロスチェーン配信テスト

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)