### PR TITLE
feat: cross-chain governance via Wormhole Executor Framework

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "lib/openzeppelin-contracts-upgradeable"]
 	path = lib/openzeppelin-contracts-upgradeable
 	url = https://github.com/OpenZeppelin/openzeppelin-contracts-upgradeable
+[submodule "lib/wormhole-solidity-sdk"]
+	path = lib/wormhole-solidity-sdk
+	url = https://github.com/wormhole-foundation/wormhole-solidity-sdk

--- a/foundry.lock
+++ b/foundry.lock
@@ -1,14 +1,20 @@
 {
-  "lib/openzeppelin-contracts": {
-    "rev": "dbb6104ce834628e473d2173bbc9d47f81a9eec3"
-  },
   "lib/forge-std": {
     "rev": "07263d193d621c4b2b0ce8b4d54af58f6957d97d"
+  },
+  "lib/openzeppelin-contracts": {
+    "rev": "dbb6104ce834628e473d2173bbc9d47f81a9eec3"
   },
   "lib/openzeppelin-contracts-upgradeable": {
     "rev": "723f8cab09cdae1aca9ec9cc1cfa040c2d4b06c1"
   },
   "lib/openzeppelin-foundry-upgrades": {
     "rev": "4cd15fc50b141c77d8cc9ff8efb44d00e841a299"
+  },
+  "lib/wormhole-solidity-sdk": {
+    "tag": {
+      "name": "v1.1.0",
+      "rev": "d80e0f6cd16f281f3f9df435e98e823b4212b2ad"
+    }
   }
 }

--- a/remappings.txt
+++ b/remappings.txt
@@ -7,3 +7,5 @@ openzeppelin-contracts-upgradeable/=lib/openzeppelin-contracts-upgradeable/
 openzeppelin-contracts/=lib/openzeppelin-contracts/
 openzeppelin-foundry-upgrades/=lib/openzeppelin-foundry-upgrades/src/
 solidity-stringutils/=lib/openzeppelin-foundry-upgrades/lib/solidity-stringutils/
+wormhole-sdk/=lib/wormhole-solidity-sdk/src/
+wormhole-solidity-sdk/=lib/wormhole-solidity-sdk/src/

--- a/script/DeployGovernanceReceiver.s.sol
+++ b/script/DeployGovernanceReceiver.s.sol
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.30;
+
+import {Script} from "forge-std/Script.sol";
+import {console} from "forge-std/console.sol";
+import {GovernanceReceiver} from "../src/governance/GovernanceReceiver.sol";
+import {TimelockController} from "@openzeppelin/contracts/governance/TimelockController.sol";
+
+/**
+ * @title DeployGovernanceReceiver
+ * @notice Deployment script for Polygon-side cross-chain governance infrastructure (Executor Framework)
+ *
+ * Deploys:
+ * - TimelockController (1 day delay, GovernanceReceiver as proposer, anyone as executor)
+ * - GovernanceReceiver (receives Wormhole Executor VAAs, schedules on Timelock)
+ *
+ * Required environment variables:
+ * - PRIVATE_KEY: Private key of the deployer
+ *
+ * Optional environment variables:
+ * - CORE_BRIDGE: Wormhole Core Bridge address on Polygon
+ *   (defaults to CORE_BRIDGE_POLYGON if unset)
+ *
+ * Post-deployment steps:
+ * 1. Deploy GovernanceSender on Ethereum
+ * 2. Call receiver.setGovernanceSender(senderAddress) on Polygon
+ * 3. Call receiver.setEmergencyGuardian(multisigAddress) on Polygon
+ *    (MUST be done BEFORE transferring ownership to Timelock)
+ * 4. Transfer GovernanceReceiver ownership to Polygon Timelock
+ * 5. Transfer PCEToken ownership to Polygon Timelock (owner EOA tx)
+ *
+ * Usage:
+ * forge script script/DeployGovernanceReceiver.s.sol --rpc-url polygon --broadcast
+ */
+contract DeployGovernanceReceiver is Script {
+    /// @notice Polygon Timelock delay: 1 day
+    uint256 public constant TIMELOCK_DELAY = 1 days;
+
+    /// @notice Wormhole Core Bridge on Polygon mainnet
+    address public constant CORE_BRIDGE_POLYGON = 0x7A4B5a56256163F07b2C80A7cA55aBE66c4ec4d7;
+
+    function run() external returns (address receiverAddr, address timelockAddr) {
+        uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
+        address deployer = vm.addr(deployerPrivateKey);
+        address coreBridge = vm.envOr("CORE_BRIDGE", CORE_BRIDGE_POLYGON);
+
+        vm.startBroadcast(deployerPrivateKey);
+
+        // Step 1: Deploy Polygon TimelockController
+        address[] memory proposers = new address[](0);
+        address[] memory executors = new address[](0);
+        TimelockController timelock = new TimelockController(
+            TIMELOCK_DELAY, proposers, executors, deployer
+        );
+        timelockAddr = address(timelock);
+
+        // Step 2: Deploy GovernanceReceiver
+        GovernanceReceiver receiver = new GovernanceReceiver(coreBridge, timelockAddr, deployer);
+        receiverAddr = address(receiver);
+
+        // Step 3: Grant PROPOSER_ROLE to GovernanceReceiver
+        timelock.grantRole(timelock.PROPOSER_ROLE(), receiverAddr);
+
+        // Step 4: Grant CANCELLER_ROLE to GovernanceReceiver
+        timelock.grantRole(timelock.CANCELLER_ROLE(), receiverAddr);
+
+        // Step 5: Grant EXECUTOR_ROLE to address(0) — anyone can execute
+        timelock.grantRole(timelock.EXECUTOR_ROLE(), address(0));
+
+        // Step 6: Renounce admin role
+        timelock.renounceRole(timelock.DEFAULT_ADMIN_ROLE(), deployer);
+
+        vm.stopBroadcast();
+
+        console.log("\nDeployment Summary:");
+        console.log("===================");
+        console.log("GovernanceReceiver:", receiverAddr);
+        console.log("Polygon Timelock:", timelockAddr);
+        console.log("Timelock Delay:", TIMELOCK_DELAY, "seconds");
+        console.log("Wormhole Core Bridge:", coreBridge);
+
+        console.log("\n  NEXT STEPS:");
+        console.log("1. Deploy GovernanceSender on Ethereum");
+        console.log("2. Call receiver.setGovernanceSender(senderAddress) on Polygon");
+        console.log("3. Call receiver.setEmergencyGuardian(multisigAddress) on Polygon");
+        console.log("4. Transfer GovernanceReceiver ownership to Polygon Timelock");
+        console.log("5. Transfer PCEToken ownership to Polygon Timelock (owner EOA tx)");
+    }
+}

--- a/script/DeployGovernanceSender.s.sol
+++ b/script/DeployGovernanceSender.s.sol
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.30;
+
+import {Script} from "forge-std/Script.sol";
+import {console} from "forge-std/console.sol";
+import {GovernanceSender} from "../src/governance/GovernanceSender.sol";
+import {toUniversalAddress} from "wormhole-solidity-sdk/Utils.sol";
+
+/**
+ * @title DeployGovernanceSender
+ * @notice Deployment script for Ethereum-side cross-chain governance (Executor Framework)
+ *
+ * Deploys:
+ * - GovernanceSender (sends governance proposals cross-chain via Wormhole Executor)
+ *
+ * Required environment variables:
+ * - GOVERNANCE_RECEIVER: Address of GovernanceReceiver on Polygon
+ * - ETHEREUM_TIMELOCK: Address of Ethereum TimelockController (will become owner)
+ * - PRIVATE_KEY: Private key of the deployer
+ *
+ * Optional environment variables:
+ * - CORE_BRIDGE: Wormhole Core Bridge address on Ethereum
+ *   (defaults to CORE_BRIDGE_ETHEREUM if unset)
+ * - EXECUTOR_QUOTER_ROUTER: Address of ExecutorQuoterRouter on Ethereum
+ *   (defaults to EXECUTOR_QUOTER_ROUTER_ETHEREUM if unset)
+ * - QUOTER_ADDRESS: Address of on-chain quoter
+ *   (defaults to QUOTER_ADDRESS_DEFAULT if unset)
+ * - GAS_LIMIT: Gas limit for cross-chain delivery (defaults to 500_000)
+ *
+ * Post-deployment steps:
+ * 1. Call receiver.setGovernanceSender(senderAddress) on Polygon
+ * 2. Pre-fund GovernanceSender with ETH buffer for Wormhole Executor fees
+ * 3. Verify contract on Etherscan
+ * 4. Test with a governance proposal
+ *
+ * Usage:
+ * forge script script/DeployGovernanceSender.s.sol --rpc-url ethereum --broadcast
+ */
+contract DeployGovernanceSender is Script {
+    /// @notice Gas limit for cross-chain delivery on Polygon
+    uint128 public constant GAS_LIMIT = 500_000;
+
+    /// @notice Wormhole Core Bridge on Ethereum mainnet
+    address public constant CORE_BRIDGE_ETHEREUM = 0x98f3c9e6E3fAce36bAAd05FE09d375Ef1464288B;
+
+    /// @notice ExecutorQuoterRouter on Ethereum mainnet
+    address public constant EXECUTOR_QUOTER_ROUTER_ETHEREUM = 0xF22F1c0A3a8Cb42F695601731974784C499C4EF3;
+
+    /// @notice Default on-chain quoter (Wormhole Labs)
+    address public constant QUOTER_ADDRESS_DEFAULT = 0xA25862D222Eb8343505c12d96e097e4332468D60;
+
+    function run() external returns (address senderAddr) {
+        address governanceReceiver = vm.envAddress("GOVERNANCE_RECEIVER");
+        address ethereumTimelock = vm.envAddress("ETHEREUM_TIMELOCK");
+        uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
+
+        address coreBridge = vm.envOr("CORE_BRIDGE", CORE_BRIDGE_ETHEREUM);
+        address executorQuoterRouter = vm.envOr("EXECUTOR_QUOTER_ROUTER", EXECUTOR_QUOTER_ROUTER_ETHEREUM);
+        address quoterAddress = vm.envOr("QUOTER_ADDRESS", QUOTER_ADDRESS_DEFAULT);
+        uint256 gasLimitRaw = vm.envOr("GAS_LIMIT", uint256(GAS_LIMIT));
+        require(gasLimitRaw <= type(uint128).max, "GAS_LIMIT exceeds uint128 max");
+        // forge-lint: disable-next-line(unsafe-typecast)
+        uint128 gasLimitVal = uint128(gasLimitRaw);
+
+        bytes32 receiverBytes32 = toUniversalAddress(governanceReceiver);
+
+        vm.startBroadcast(deployerPrivateKey);
+
+        GovernanceSender sender = new GovernanceSender(
+            coreBridge, executorQuoterRouter, receiverBytes32, gasLimitVal, quoterAddress, ethereumTimelock
+        );
+        senderAddr = address(sender);
+
+        vm.stopBroadcast();
+
+        console.log("\nDeployment Summary:");
+        console.log("===================");
+        console.log("GovernanceSender:", senderAddr);
+        console.log("Owner (Ethereum Timelock):", ethereumTimelock);
+        console.log("Governance Receiver (Polygon):", governanceReceiver);
+        console.log("Gas Limit:", uint256(gasLimitVal));
+        console.log("Core Bridge:", coreBridge);
+        console.log("ExecutorQuoterRouter:", executorQuoterRouter);
+        console.log("Quoter:", quoterAddress);
+
+        console.log("\n  NEXT STEPS:");
+        console.log("1. On Polygon: receiver.setGovernanceSender(toUniversalAddress(", senderAddr, "))");
+        console.log("2. Pre-fund GovernanceSender with ETH buffer for Wormhole Executor fees");
+        console.log("3. Verify contract on Etherscan");
+        console.log("4. Test with a governance proposal");
+    }
+}

--- a/src/governance/GovernanceReceiver.sol
+++ b/src/governance/GovernanceReceiver.sol
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.30;
+
+import {ExecutorReceive, InvalidPeer} from "wormhole-solidity-sdk/Executor/Integration.sol";
+import {SequenceReplayProtectionLib} from "wormhole-solidity-sdk/libraries/ReplayProtection.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {TimelockController} from "@openzeppelin/contracts/governance/TimelockController.sol";
+import {CHAIN_ID_ETHEREUM} from "wormhole-solidity-sdk/constants/Chains.sol";
+
+/**
+ * @title GovernanceReceiver
+ * @notice Polygon-side contract that receives governance proposals from Ethereum via Wormhole Executor
+ * @dev Receives cross-chain VAAs from GovernanceSender and schedules them on a
+ *      local TimelockController for delayed execution.
+ *
+ * Flow: GovernanceSender (Ethereum) → Wormhole Executor → GovernanceReceiver → Polygon Timelock → PCEToken
+ */
+contract GovernanceReceiver is ExecutorReceive, Ownable {
+    using SequenceReplayProtectionLib for *;
+
+    /// @notice Wormhole chain ID for Ethereum
+    uint16 public constant SOURCE_CHAIN = CHAIN_ID_ETHEREUM;
+
+    /// @notice Polygon TimelockController for delayed execution
+    TimelockController public immutable TIMELOCK;
+
+    /// @notice Address of GovernanceSender on Ethereum (bytes32, left-padded)
+    bytes32 public governanceSender;
+
+    /// @notice Emergency guardian that can cancel scheduled operations without timelock delay
+    address public emergencyGuardian;
+
+    event CrossChainGovernanceReceived(
+        uint64 indexed sequence,
+        address[] targets,
+        uint256[] values,
+        bytes32 salt
+    );
+    event GovernanceSenderUpdated(bytes32 indexed oldSender, bytes32 indexed newSender);
+    event EmergencyGuardianUpdated(address indexed oldGuardian, address indexed newGuardian);
+
+    error InvalidSender();
+    error InvalidTimelock();
+    error NotOwnerOrGuardian();
+    error GovernanceSenderNotSet();
+    error WithdrawFailed();
+
+    /**
+     * @param _coreBridge Address of the Wormhole Core Bridge on Polygon
+     * @param _timelock Address of the Polygon TimelockController
+     * @param _owner Initial owner (deployer)
+     */
+    constructor(
+        address _coreBridge,
+        address _timelock,
+        address _owner
+    ) ExecutorReceive(_coreBridge) Ownable(_owner) {
+        if (_timelock == address(0) || _timelock.code.length == 0) revert InvalidTimelock();
+        TIMELOCK = TimelockController(payable(_timelock));
+    }
+
+    /// @dev Required by ExecutorSharedBase — returns peer address for source chain
+    function _getPeer(uint16 chainId) internal view override returns (bytes32) {
+        if (chainId == SOURCE_CHAIN) return governanceSender;
+        return bytes32(0);
+    }
+
+    /// @dev Override to check governanceSender is set and source chain is Ethereum
+    function _checkPeer(uint16 chainId, bytes32 peerAddress) internal view override {
+        if (governanceSender == bytes32(0)) revert GovernanceSenderNotSet();
+        if (chainId != SOURCE_CHAIN) revert InvalidPeer();
+        if (governanceSender != peerAddress) revert InvalidPeer();
+    }
+
+    /// @dev Replay protection using Wormhole SDK's sequence-based protection
+    function _replayProtect(
+        uint16 emitterChainId,
+        bytes32 emitterAddress,
+        uint64 sequence,
+        bytes calldata /* encodedVaa */
+    ) internal override {
+        SequenceReplayProtectionLib.replayProtect(emitterChainId, emitterAddress, sequence);
+    }
+
+    // Use default msg.value == 0 check (no override needed)
+
+    /**
+     * @dev Process the received VAA payload — decode and schedule on Polygon Timelock
+     */
+    function _executeVaa(
+        bytes calldata payload,
+        uint32, /* timestamp */
+        uint16, /* peerChain */
+        bytes32, /* peerAddress */
+        uint64 sequence,
+        uint8 /* consistencyLevel */
+    ) internal override {
+        // Decode payload
+        (
+            address[] memory targets,
+            uint256[] memory values,
+            bytes[] memory calldatas,
+            bytes32 salt
+        ) = abi.decode(payload, (address[], uint256[], bytes[], bytes32));
+
+        // Schedule on Polygon Timelock
+        uint256 minDelay = TIMELOCK.getMinDelay();
+        TIMELOCK.scheduleBatch(targets, values, calldatas, bytes32(0), salt, minDelay);
+
+        emit CrossChainGovernanceReceived(sequence, targets, values, salt);
+    }
+
+    /**
+     * @notice Cancel a scheduled batch operation on the Polygon Timelock
+     * @dev Callable by owner or emergencyGuardian.
+     *      If ownership is still held by an EOA or multisig, the owner path can cancel immediately.
+     *      After ownership is transferred to the Polygon Timelock, calls through the owner path are
+     *      themselves timelock-controlled and therefore are not a fast-cancel mechanism; in that
+     *      deployment model, only emergencyGuardian provides immediate cancellation.
+     *      Requires this contract to have CANCELLER_ROLE on the Timelock.
+     * @param id The operation identifier (from hashOperationBatch)
+     */
+    function cancelScheduledBatch(bytes32 id) external {
+        if (msg.sender != owner() && msg.sender != emergencyGuardian) {
+            revert NotOwnerOrGuardian();
+        }
+        TIMELOCK.cancel(id);
+    }
+
+    /**
+     * @notice Set the GovernanceSender address on Ethereum
+     * @param _governanceSender Address of the GovernanceSender contract (bytes32, left-padded)
+     */
+    function setGovernanceSender(bytes32 _governanceSender) external onlyOwner {
+        if (_governanceSender == bytes32(0)) revert InvalidSender();
+        bytes32 old = governanceSender;
+        governanceSender = _governanceSender;
+        emit GovernanceSenderUpdated(old, _governanceSender);
+    }
+
+    /**
+     * @notice Set or remove the emergency guardian address for fast cancellation
+     * @param _guardian Address of the emergency guardian (e.g., multisig), or address(0) to disable
+     */
+    function setEmergencyGuardian(address _guardian) external onlyOwner {
+        address old = emergencyGuardian;
+        emergencyGuardian = _guardian;
+        emit EmergencyGuardianUpdated(old, _guardian);
+    }
+
+    /**
+     * @notice Withdraw ETH accidentally sent to this contract
+     * @param to Recipient address
+     * @param amount Amount of ETH to withdraw
+     */
+    function withdrawETH(address payable to, uint256 amount) external onlyOwner {
+        if (to == address(0)) revert WithdrawFailed();
+        (bool success,) = to.call{value: amount}("");
+        if (!success) revert WithdrawFailed();
+    }
+}

--- a/src/governance/GovernanceSender.sol
+++ b/src/governance/GovernanceSender.sol
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.30;
+
+import {ExecutorSendQuoteOnChain} from "wormhole-solidity-sdk/Executor/Integration.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {CONSISTENCY_LEVEL_FINALIZED} from "wormhole-solidity-sdk/constants/ConsistencyLevel.sol";
+import {CHAIN_ID_POLYGON} from "wormhole-solidity-sdk/constants/Chains.sol";
+import {toUniversalAddress} from "wormhole-solidity-sdk/Utils.sol";
+import {RelayInstructionLib} from "wormhole-solidity-sdk/Executor/RelayInstruction.sol";
+import {RequestLib} from "wormhole-solidity-sdk/Executor/Request.sol";
+
+/**
+ * @title GovernanceSender
+ * @notice Ethereum-side contract that sends governance proposals cross-chain via Wormhole Executor
+ * @dev Owned by the Ethereum TimelockController. Encodes batch operations and sends
+ *      them to GovernanceReceiver on Polygon through the Wormhole Executor Framework.
+ *
+ * Flow: Ethereum Governor → Timelock → GovernanceSender → Wormhole Executor → GovernanceReceiver (Polygon)
+ */
+contract GovernanceSender is ExecutorSendQuoteOnChain, Ownable {
+    /// @notice Wormhole chain ID for Polygon
+    uint16 public constant TARGET_CHAIN = CHAIN_ID_POLYGON;
+
+    /// @notice Address of GovernanceReceiver on Polygon (stored as bytes32)
+    bytes32 public governanceReceiver;
+
+    /// @notice Gas limit for cross-chain delivery on Polygon
+    uint128 public gasLimit;
+
+    /// @notice On-chain quoter address for fee estimation
+    address public quoterAddress;
+
+    event CrossChainGovernanceSent(
+        uint64 indexed sequence,
+        address[] targets,
+        uint256[] values,
+        bytes32 salt
+    );
+    event GovernanceReceiverUpdated(bytes32 indexed oldReceiver, bytes32 indexed newReceiver);
+    event GasLimitUpdated(uint128 oldGasLimit, uint128 newGasLimit);
+    event QuoterAddressUpdated(address indexed oldQuoter, address indexed newQuoter);
+
+    error InvalidReceiver();
+    error InvalidGasLimit();
+    error ArrayLengthMismatch();
+    error EmptyProposal();
+    error InsufficientFee(uint256 required, uint256 provided);
+    error WithdrawFailed();
+    error InvalidQuoter();
+
+    /**
+     * @param _coreBridge Address of the Wormhole Core Bridge on Ethereum
+     * @param _executorQuoterRouter Address of the Wormhole ExecutorQuoterRouter on Ethereum
+     * @param _governanceReceiver Address of GovernanceReceiver on Polygon (bytes32, left-padded)
+     * @param _gasLimit Gas limit for delivery on Polygon
+     * @param _quoterAddress Address of the on-chain quoter
+     * @param _owner Initial owner (typically the Ethereum Timelock, or a deployer EOA that later transfers ownership)
+     */
+    constructor(
+        address _coreBridge,
+        address _executorQuoterRouter,
+        bytes32 _governanceReceiver,
+        uint128 _gasLimit,
+        address _quoterAddress,
+        address _owner
+    ) ExecutorSendQuoteOnChain(_coreBridge, _executorQuoterRouter) Ownable(_owner) {
+        if (_governanceReceiver == bytes32(0)) revert InvalidReceiver();
+        if (_gasLimit == 0) revert InvalidGasLimit();
+        if (_quoterAddress == address(0) || _quoterAddress.code.length == 0) revert InvalidQuoter();
+
+        governanceReceiver = _governanceReceiver;
+        gasLimit = _gasLimit;
+        quoterAddress = _quoterAddress;
+    }
+
+    /// @dev Required by ExecutorSharedBase — returns peer address for target chain
+    function _getPeer(uint16 chainId) internal view override returns (bytes32) {
+        if (chainId == TARGET_CHAIN) return governanceReceiver;
+        return bytes32(0);
+    }
+
+    /**
+     * @notice Send a batch governance operation cross-chain to Polygon
+     * @dev Pays fees from contract balance + msg.value. Pre-fund this contract
+     *      with ETH to absorb fee fluctuations between proposal creation and execution.
+     * @param targets Target contract addresses on Polygon
+     * @param values Native token values for each call (typically 0 on Polygon)
+     * @param calldatas Encoded function calls
+     * @param salt Unique salt for TimelockController scheduling
+     */
+    function sendCrossChainGovernance(
+        address[] calldata targets,
+        uint256[] calldata values,
+        bytes[] calldata calldatas,
+        bytes32 salt
+    ) external payable onlyOwner {
+        if (targets.length == 0) revert EmptyProposal();
+        if (targets.length != values.length || targets.length != calldatas.length) {
+            revert ArrayLengthMismatch();
+        }
+
+        bytes memory payload = abi.encode(targets, values, calldatas, salt);
+
+        uint256 totalCost = quoteDeliveryPrice();
+        if (address(this).balance < totalCost) {
+            revert InsufficientFee(totalCost, address(this).balance);
+        }
+
+        uint64 sequence = _publishAndRelay(
+            payload,
+            CONSISTENCY_LEVEL_FINALIZED,
+            totalCost,
+            TARGET_CHAIN,
+            address(this), // refund to this contract
+            quoterAddress,
+            gasLimit,
+            0, // no msg.value on destination
+            "" // no extra relay instructions
+        );
+
+        emit CrossChainGovernanceSent(sequence, targets, values, salt);
+    }
+
+    /**
+     * @notice Quote the delivery price for a cross-chain governance message
+     * @return totalCost Amount of ETH required (executor fee + core bridge message fee)
+     */
+    function quoteDeliveryPrice() public view returns (uint256 totalCost) {
+        bytes memory relayInstructions = RelayInstructionLib.encodeGas(gasLimit, 0);
+        bytes memory requestBytes = RequestLib.encodeVaaMultiSigRequest(
+            _chainId, toUniversalAddress(address(this)), 0
+        );
+
+        uint256 executorFee = _executorQuoterRouter.quoteExecution(
+            TARGET_CHAIN, governanceReceiver, address(this), quoterAddress, requestBytes, relayInstructions
+        );
+
+        totalCost = executorFee + _coreBridge.messageFee();
+    }
+
+    /**
+     * @notice Update the GovernanceReceiver address on Polygon
+     * @param _governanceReceiver New receiver address (bytes32, left-padded)
+     */
+    function setGovernanceReceiver(bytes32 _governanceReceiver) external onlyOwner {
+        if (_governanceReceiver == bytes32(0)) revert InvalidReceiver();
+        bytes32 old = governanceReceiver;
+        governanceReceiver = _governanceReceiver;
+        emit GovernanceReceiverUpdated(old, _governanceReceiver);
+    }
+
+    /**
+     * @notice Update the gas limit for cross-chain delivery
+     * @param _gasLimit New gas limit
+     */
+    function setGasLimit(uint128 _gasLimit) external onlyOwner {
+        if (_gasLimit == 0) revert InvalidGasLimit();
+        uint128 old = gasLimit;
+        gasLimit = _gasLimit;
+        emit GasLimitUpdated(old, _gasLimit);
+    }
+
+    /**
+     * @notice Update the on-chain quoter address
+     * @param _quoterAddress New quoter address
+     */
+    function setQuoterAddress(address _quoterAddress) external onlyOwner {
+        if (_quoterAddress == address(0) || _quoterAddress.code.length == 0) revert InvalidQuoter();
+        address old = quoterAddress;
+        quoterAddress = _quoterAddress;
+        emit QuoterAddressUpdated(old, _quoterAddress);
+    }
+
+    /**
+     * @notice Withdraw ETH from this contract
+     * @param to Recipient address
+     * @param amount Amount of ETH to withdraw
+     */
+    function withdrawETH(address payable to, uint256 amount) external onlyOwner {
+        if (to == address(0)) revert WithdrawFailed();
+        (bool success,) = to.call{value: amount}("");
+        if (!success) revert WithdrawFailed();
+    }
+
+    /// @notice Allow this contract to receive ETH for pre-funding relay fees
+    receive() external payable {}
+}

--- a/test/GovernanceReceiver.t.sol
+++ b/test/GovernanceReceiver.t.sol
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.30;
+
+import {Test} from "forge-std/Test.sol";
+import {GovernanceReceiver} from "../src/governance/GovernanceReceiver.sol";
+import {TimelockController} from "@openzeppelin/contracts/governance/TimelockController.sol";
+import {toUniversalAddress} from "wormhole-solidity-sdk/Utils.sol";
+
+/// @dev Minimal mock for Wormhole Core Bridge on Polygon
+contract MockCoreBridgePolygon {
+    function chainId() external pure returns (uint16) { return 5; } // Polygon
+    function messageFee() external pure returns (uint256) { return 0; }
+}
+
+contract GovernanceReceiverTest is Test {
+    GovernanceReceiver public receiver;
+    TimelockController public timelock;
+    MockCoreBridgePolygon public coreBridge;
+
+    address public owner = address(this);
+    bytes32 public governanceSender = toUniversalAddress(address(0x5EED));
+
+    uint256 public constant TIMELOCK_DELAY = 1 days;
+
+    function setUp() public {
+        coreBridge = new MockCoreBridgePolygon();
+
+        // Deploy TimelockController
+        address[] memory proposers = new address[](0);
+        address[] memory executors = new address[](0);
+        timelock = new TimelockController(TIMELOCK_DELAY, proposers, executors, owner);
+
+        // Deploy GovernanceReceiver
+        receiver = new GovernanceReceiver(address(coreBridge), address(timelock), owner);
+
+        // Set governance sender
+        receiver.setGovernanceSender(governanceSender);
+
+        // Grant roles to receiver
+        timelock.grantRole(timelock.PROPOSER_ROLE(), address(receiver));
+        timelock.grantRole(timelock.CANCELLER_ROLE(), address(receiver));
+        timelock.grantRole(timelock.EXECUTOR_ROLE(), address(0));
+
+        // Renounce admin
+        timelock.renounceRole(timelock.DEFAULT_ADMIN_ROLE(), owner);
+    }
+
+    function testConstructor() public view {
+        assertEq(address(receiver.TIMELOCK()), address(timelock));
+        assertEq(receiver.owner(), owner);
+        assertEq(receiver.SOURCE_CHAIN(), 2); // Ethereum
+    }
+
+    function testConstructorRevertsInvalidTimelock() public {
+        vm.expectRevert(GovernanceReceiver.InvalidTimelock.selector);
+        new GovernanceReceiver(address(coreBridge), address(0), owner);
+    }
+
+    function testSetGovernanceSender() public {
+        GovernanceReceiver newReceiver = new GovernanceReceiver(
+            address(coreBridge), address(timelock), owner
+        );
+        bytes32 newSender = toUniversalAddress(address(0xBEEF));
+        newReceiver.setGovernanceSender(newSender);
+        assertEq(newReceiver.governanceSender(), newSender);
+    }
+
+    function testSetGovernanceSenderRevertsInvalid() public {
+        vm.expectRevert(GovernanceReceiver.InvalidSender.selector);
+        receiver.setGovernanceSender(bytes32(0));
+    }
+
+    function testSetGovernanceSenderRevertsOnlyOwner() public {
+        vm.prank(address(0xDEAD));
+        vm.expectRevert();
+        receiver.setGovernanceSender(toUniversalAddress(address(0xBEEF)));
+    }
+
+    function testGovernanceSenderNotSet() public {
+        GovernanceReceiver freshReceiver = new GovernanceReceiver(
+            address(coreBridge), address(timelock), owner
+        );
+        // governanceSender not set — _checkPeer should revert
+        // We can't easily call executeVAAv1 without a valid VAA, but we test the setter path
+        assertEq(freshReceiver.governanceSender(), bytes32(0));
+    }
+
+    function testCancelScheduledBatchByOwner() public {
+        // We need to schedule something first via Timelock directly (since executeVAAv1 needs real VAA)
+        // Grant PROPOSER to this test contract temporarily
+        // Since admin was renounced, we test cancel path with a direct Timelock schedule
+        // For now, test the access control
+        vm.expectRevert(); // will fail because no such operation exists
+        receiver.cancelScheduledBatch(bytes32(uint256(1)));
+    }
+
+    function testCancelScheduledBatchByGuardian() public {
+        address guardian = address(0xAAAA);
+        receiver.setEmergencyGuardian(guardian);
+
+        vm.prank(guardian);
+        vm.expectRevert(); // no such operation
+        receiver.cancelScheduledBatch(bytes32(uint256(1)));
+    }
+
+    function testCancelScheduledBatchRevertsUnauthorized() public {
+        vm.prank(address(0xDEAD));
+        vm.expectRevert(GovernanceReceiver.NotOwnerOrGuardian.selector);
+        receiver.cancelScheduledBatch(bytes32(0));
+    }
+
+    function testSetEmergencyGuardian() public {
+        address guardian = address(0xBBBB);
+        receiver.setEmergencyGuardian(guardian);
+        assertEq(receiver.emergencyGuardian(), guardian);
+    }
+
+    function testSetEmergencyGuardianToZeroDisables() public {
+        receiver.setEmergencyGuardian(address(0xBBBB));
+        receiver.setEmergencyGuardian(address(0));
+        assertEq(receiver.emergencyGuardian(), address(0));
+    }
+
+    function testSetEmergencyGuardianRevertsOnlyOwner() public {
+        vm.prank(address(0xDEAD));
+        vm.expectRevert();
+        receiver.setEmergencyGuardian(address(0xBBBB));
+    }
+
+    function testWithdrawETH() public {
+        vm.deal(address(receiver), 1 ether);
+        address payable recipient = payable(address(0xCAFE));
+        receiver.withdrawETH(recipient, 0.5 ether);
+        assertEq(recipient.balance, 0.5 ether);
+        assertEq(address(receiver).balance, 0.5 ether);
+    }
+
+    function testWithdrawETHRevertsOnlyOwner() public {
+        vm.deal(address(receiver), 1 ether);
+        vm.prank(address(0xDEAD));
+        vm.expectRevert();
+        receiver.withdrawETH(payable(address(0xCAFE)), 0.5 ether);
+    }
+
+    function testWithdrawETHRevertsZeroAddress() public {
+        vm.deal(address(receiver), 1 ether);
+        vm.expectRevert(GovernanceReceiver.WithdrawFailed.selector);
+        receiver.withdrawETH(payable(address(0)), 0.5 ether);
+    }
+}

--- a/test/GovernanceReceiverHarness.t.sol
+++ b/test/GovernanceReceiverHarness.t.sol
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.30;
+
+import {Test} from "forge-std/Test.sol";
+import {GovernanceReceiver} from "../src/governance/GovernanceReceiver.sol";
+import {TimelockController} from "@openzeppelin/contracts/governance/TimelockController.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {toUniversalAddress} from "wormhole-solidity-sdk/Utils.sol";
+
+/// @dev Harness that exposes GovernanceReceiver internals for testing
+contract GovernanceReceiverHarness is GovernanceReceiver {
+    constructor(address _coreBridge, address _timelock, address _owner)
+        GovernanceReceiver(_coreBridge, _timelock, _owner)
+    {}
+
+    /// @dev Expose _executeVaa for direct testing
+    function exposed_executeVaa(
+        bytes calldata payload,
+        uint32 timestamp,
+        uint16 peerChain,
+        bytes32 peerAddress,
+        uint64 sequence,
+        uint8 consistencyLevel
+    ) external {
+        _executeVaa(payload, timestamp, peerChain, peerAddress, sequence, consistencyLevel);
+    }
+}
+
+/// @dev Mock Ownable ERC20 that mimics PCEToken
+contract MockOwnableToken is ERC20, Ownable {
+    constructor() ERC20("Mock PCE", "MPCE") Ownable(msg.sender) {}
+    function mint(address to, uint256 amount) external onlyOwner { _mint(to, amount); }
+}
+
+/// @dev Mock Core Bridge for Polygon
+contract MockCoreBridgePolygonHarness {
+    function chainId() external pure returns (uint16) { return 5; }
+    function messageFee() external pure returns (uint256) { return 0; }
+}
+
+/**
+ * @title GovernanceReceiverHarnessTest
+ * @notice Tests _executeVaa logic directly via harness, plus cancel success path
+ */
+contract GovernanceReceiverHarnessTest is Test {
+    GovernanceReceiverHarness public receiver;
+    TimelockController public timelock;
+    MockCoreBridgePolygonHarness public coreBridge;
+    MockOwnableToken public token;
+
+    address public deployer = address(this);
+    bytes32 public senderAddress = toUniversalAddress(address(0x5EED));
+    uint256 public constant TIMELOCK_DELAY = 1 days;
+
+    function setUp() public {
+        coreBridge = new MockCoreBridgePolygonHarness();
+        token = new MockOwnableToken();
+
+        address[] memory proposers = new address[](0);
+        address[] memory executors = new address[](0);
+        timelock = new TimelockController(TIMELOCK_DELAY, proposers, executors, deployer);
+
+        receiver = new GovernanceReceiverHarness(address(coreBridge), address(timelock), deployer);
+        receiver.setGovernanceSender(senderAddress);
+
+        // Grant roles
+        timelock.grantRole(timelock.PROPOSER_ROLE(), address(receiver));
+        timelock.grantRole(timelock.CANCELLER_ROLE(), address(receiver));
+        timelock.grantRole(timelock.EXECUTOR_ROLE(), address(0));
+
+        // Transfer token to Timelock
+        token.transferOwnership(address(timelock));
+
+        // Renounce admin
+        timelock.renounceRole(timelock.DEFAULT_ADMIN_ROLE(), deployer);
+    }
+
+    function testExecuteVaaSchedulesBatch() public {
+        address mintRecipient = address(0xABCD);
+        uint256 mintAmount = 1000 ether;
+
+        address[] memory targets = new address[](1);
+        targets[0] = address(token);
+        uint256[] memory values = new uint256[](1);
+        bytes[] memory calldatas = new bytes[](1);
+        calldatas[0] = abi.encodeWithSignature("mint(address,uint256)", mintRecipient, mintAmount);
+        bytes32 salt = keccak256("harness-test-1");
+
+        bytes memory payload = abi.encode(targets, values, calldatas, salt);
+
+        // Call _executeVaa directly
+        receiver.exposed_executeVaa(payload, uint32(block.timestamp), 2, senderAddress, 1, 1);
+
+        // Verify operation is pending on Timelock
+        bytes32 timelockId = timelock.hashOperationBatch(targets, values, calldatas, bytes32(0), salt);
+        assertTrue(timelock.isOperationPending(timelockId));
+
+        // Wait and execute
+        vm.warp(block.timestamp + TIMELOCK_DELAY + 1);
+        assertTrue(timelock.isOperationReady(timelockId));
+
+        timelock.executeBatch(targets, values, calldatas, bytes32(0), salt);
+        assertTrue(timelock.isOperationDone(timelockId));
+
+        // Verify token minted
+        assertEq(token.balanceOf(mintRecipient), mintAmount);
+    }
+
+    function testExecuteVaaBatchOperations() public {
+        address mintRecipient = address(0xABCD);
+
+        address[] memory targets = new address[](1);
+        targets[0] = address(token);
+        uint256[] memory values = new uint256[](1);
+        bytes[] memory calldatas = new bytes[](1);
+        calldatas[0] = abi.encodeWithSignature("mint(address,uint256)", mintRecipient, 500 ether);
+        bytes32 salt = keccak256("harness-batch-1");
+
+        bytes memory payload = abi.encode(targets, values, calldatas, salt);
+        receiver.exposed_executeVaa(payload, uint32(block.timestamp), 2, senderAddress, 2, 1);
+
+        // Wait and execute
+        vm.warp(block.timestamp + TIMELOCK_DELAY + 1);
+        timelock.executeBatch(targets, values, calldatas, bytes32(0), salt);
+
+        assertEq(token.balanceOf(mintRecipient), 500 ether);
+    }
+
+    function testCancelScheduledBatchSuccess() public {
+        // Schedule via _executeVaa
+        address[] memory targets = new address[](1);
+        targets[0] = address(token);
+        uint256[] memory values = new uint256[](1);
+        bytes[] memory calldatas = new bytes[](1);
+        calldatas[0] = abi.encodeWithSignature("mint(address,uint256)", address(0xABCD), 100 ether);
+        bytes32 salt = keccak256("cancel-test");
+
+        bytes memory payload = abi.encode(targets, values, calldatas, salt);
+        receiver.exposed_executeVaa(payload, uint32(block.timestamp), 2, senderAddress, 3, 1);
+
+        bytes32 timelockId = timelock.hashOperationBatch(targets, values, calldatas, bytes32(0), salt);
+        assertTrue(timelock.isOperationPending(timelockId));
+
+        // Owner cancels
+        receiver.cancelScheduledBatch(timelockId);
+        assertFalse(timelock.isOperationPending(timelockId));
+    }
+
+    function testCancelScheduledBatchByGuardianSuccess() public {
+        address guardian = address(0xAAAA);
+        receiver.setEmergencyGuardian(guardian);
+
+        // Schedule
+        address[] memory targets = new address[](1);
+        targets[0] = address(token);
+        uint256[] memory values = new uint256[](1);
+        bytes[] memory calldatas = new bytes[](1);
+        calldatas[0] = abi.encodeWithSignature("mint(address,uint256)", address(0xABCD), 100 ether);
+        bytes32 salt = keccak256("guardian-cancel-test");
+
+        bytes memory payload = abi.encode(targets, values, calldatas, salt);
+        receiver.exposed_executeVaa(payload, uint32(block.timestamp), 2, senderAddress, 4, 1);
+
+        bytes32 timelockId = timelock.hashOperationBatch(targets, values, calldatas, bytes32(0), salt);
+
+        // Guardian cancels
+        vm.prank(guardian);
+        receiver.cancelScheduledBatch(timelockId);
+        assertFalse(timelock.isOperationPending(timelockId));
+    }
+
+    function testCannotExecuteBeforeDelay() public {
+        address[] memory targets = new address[](1);
+        targets[0] = address(token);
+        uint256[] memory values = new uint256[](1);
+        bytes[] memory calldatas = new bytes[](1);
+        calldatas[0] = abi.encodeWithSignature("mint(address,uint256)", address(0xABCD), 100 ether);
+        bytes32 salt = keccak256("too-early");
+
+        bytes memory payload = abi.encode(targets, values, calldatas, salt);
+        receiver.exposed_executeVaa(payload, uint32(block.timestamp), 2, senderAddress, 5, 1);
+
+        vm.expectRevert();
+        timelock.executeBatch(targets, values, calldatas, bytes32(0), salt);
+    }
+}

--- a/test/GovernanceSender.t.sol
+++ b/test/GovernanceSender.t.sol
@@ -1,0 +1,210 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.30;
+
+import {Test} from "forge-std/Test.sol";
+import {GovernanceSender} from "../src/governance/GovernanceSender.sol";
+
+/// @dev Minimal mock for Wormhole Core Bridge
+contract MockCoreBridge {
+    uint64 public nextSequence = 1;
+
+    function chainId() external pure returns (uint16) { return 2; } // Ethereum
+    function messageFee() external pure returns (uint256) { return 0.001 ether; }
+
+    function publishMessage(uint32, bytes memory, uint8) external payable returns (uint64 sequence) {
+        sequence = nextSequence++;
+    }
+}
+
+/// @dev Minimal mock for ExecutorQuoterRouter
+contract MockExecutorQuoterRouter {
+    uint256 public executionFee = 0.009 ether;
+
+    function quoteExecution(uint16, bytes32, address, address, bytes calldata, bytes calldata)
+        external view returns (uint256)
+    {
+        return executionFee;
+    }
+
+    function requestExecution(uint16, bytes32, address, address, bytes calldata, bytes calldata)
+        external payable
+    {}
+
+    function setExecutionFee(uint256 _fee) external { executionFee = _fee; }
+}
+
+contract GovernanceSenderTest is Test {
+    GovernanceSender public sender;
+    MockCoreBridge public coreBridge;
+    MockExecutorQuoterRouter public quoterRouter;
+
+    address public owner = address(this);
+    bytes32 public receiver = bytes32(uint256(uint160(address(0xBEEF))));
+    address public quoter = address(0xAAAA);
+    uint128 public constant GAS_LIMIT = 500_000;
+
+    function setUp() public {
+        coreBridge = new MockCoreBridge();
+        quoterRouter = new MockExecutorQuoterRouter();
+        vm.etch(quoter, hex"00"); // quoter must have code
+
+        sender = new GovernanceSender(
+            address(coreBridge),
+            address(quoterRouter),
+            receiver,
+            GAS_LIMIT,
+            quoter,
+            owner
+        );
+
+        // Pre-fund sender
+        vm.deal(address(sender), 1 ether);
+    }
+
+    function testConstructor() public view {
+        assertEq(sender.governanceReceiver(), receiver);
+        assertEq(sender.gasLimit(), GAS_LIMIT);
+        assertEq(sender.quoterAddress(), quoter);
+        assertEq(sender.owner(), owner);
+        assertEq(sender.TARGET_CHAIN(), 5); // Polygon
+    }
+
+    function testConstructorRevertsInvalidReceiver() public {
+        vm.expectRevert(GovernanceSender.InvalidReceiver.selector);
+        new GovernanceSender(address(coreBridge), address(quoterRouter), bytes32(0), GAS_LIMIT, quoter, owner);
+    }
+
+    function testConstructorRevertsInvalidGasLimit() public {
+        vm.expectRevert(GovernanceSender.InvalidGasLimit.selector);
+        new GovernanceSender(address(coreBridge), address(quoterRouter), receiver, 0, quoter, owner);
+    }
+
+    function testConstructorRevertsInvalidQuoter() public {
+        vm.expectRevert(GovernanceSender.InvalidQuoter.selector);
+        new GovernanceSender(address(coreBridge), address(quoterRouter), receiver, GAS_LIMIT, address(0), owner);
+    }
+
+    function testQuoteDeliveryPrice() public view {
+        uint256 price = sender.quoteDeliveryPrice();
+        // executionFee (0.009) + messageFee (0.001) = 0.01 ether
+        assertEq(price, 0.01 ether);
+    }
+
+    function testSendCrossChainGovernance() public {
+        address[] memory targets = new address[](1);
+        targets[0] = address(0x1234);
+        uint256[] memory values = new uint256[](1);
+        bytes[] memory calldatas = new bytes[](1);
+        calldatas[0] = abi.encodeWithSignature("mint(address,uint256)", address(0x5678), 100 ether);
+        bytes32 salt = keccak256("test-salt");
+
+        vm.expectEmit(true, false, false, true);
+        emit GovernanceSender.CrossChainGovernanceSent(1, targets, values, salt);
+
+        sender.sendCrossChainGovernance(targets, values, calldatas, salt);
+    }
+
+    function testSendRevertsOnlyOwner() public {
+        address[] memory targets = new address[](1);
+        targets[0] = address(0x1234);
+        uint256[] memory values = new uint256[](1);
+        bytes[] memory calldatas = new bytes[](1);
+        calldatas[0] = hex"";
+
+        vm.prank(address(0xDEAD));
+        vm.expectRevert();
+        sender.sendCrossChainGovernance(targets, values, calldatas, bytes32(0));
+    }
+
+    function testSendRevertsEmptyProposal() public {
+        address[] memory targets = new address[](0);
+        uint256[] memory values = new uint256[](0);
+        bytes[] memory calldatas = new bytes[](0);
+
+        vm.expectRevert(GovernanceSender.EmptyProposal.selector);
+        sender.sendCrossChainGovernance(targets, values, calldatas, bytes32(0));
+    }
+
+    function testSendRevertsArrayLengthMismatch() public {
+        address[] memory targets = new address[](2);
+        uint256[] memory values = new uint256[](1);
+        bytes[] memory calldatas = new bytes[](2);
+
+        vm.expectRevert(GovernanceSender.ArrayLengthMismatch.selector);
+        sender.sendCrossChainGovernance(targets, values, calldatas, bytes32(0));
+    }
+
+    function testSendRevertsInsufficientFee() public {
+        // Deploy unfunded sender
+        GovernanceSender unfunded = new GovernanceSender(
+            address(coreBridge), address(quoterRouter), receiver, GAS_LIMIT, quoter, owner
+        );
+
+        address[] memory targets = new address[](1);
+        targets[0] = address(0x1234);
+        uint256[] memory values = new uint256[](1);
+        bytes[] memory calldatas = new bytes[](1);
+        calldatas[0] = hex"";
+
+        vm.expectRevert(
+            abi.encodeWithSelector(GovernanceSender.InsufficientFee.selector, 0.01 ether, 0)
+        );
+        unfunded.sendCrossChainGovernance(targets, values, calldatas, bytes32(0));
+    }
+
+    function testSetGovernanceReceiver() public {
+        bytes32 newReceiver = bytes32(uint256(uint160(address(0xCAFE))));
+        sender.setGovernanceReceiver(newReceiver);
+        assertEq(sender.governanceReceiver(), newReceiver);
+    }
+
+    function testSetGovernanceReceiverRevertsInvalid() public {
+        vm.expectRevert(GovernanceSender.InvalidReceiver.selector);
+        sender.setGovernanceReceiver(bytes32(0));
+    }
+
+    function testSetGasLimit() public {
+        sender.setGasLimit(1_000_000);
+        assertEq(sender.gasLimit(), 1_000_000);
+    }
+
+    function testSetGasLimitRevertsInvalid() public {
+        vm.expectRevert(GovernanceSender.InvalidGasLimit.selector);
+        sender.setGasLimit(0);
+    }
+
+    function testSetQuoterAddress() public {
+        address newQuoter = address(0xBBBB);
+        vm.etch(newQuoter, hex"00");
+        sender.setQuoterAddress(newQuoter);
+        assertEq(sender.quoterAddress(), newQuoter);
+    }
+
+    function testSetQuoterAddressRevertsInvalid() public {
+        vm.expectRevert(GovernanceSender.InvalidQuoter.selector);
+        sender.setQuoterAddress(address(0));
+    }
+
+    function testWithdrawETH() public {
+        address payable recipient = payable(address(0xCAFE));
+        sender.withdrawETH(recipient, 0.5 ether);
+        assertEq(recipient.balance, 0.5 ether);
+    }
+
+    function testWithdrawETHRevertsOnlyOwner() public {
+        vm.prank(address(0xDEAD));
+        vm.expectRevert();
+        sender.withdrawETH(payable(address(0xCAFE)), 0.5 ether);
+    }
+
+    function testWithdrawETHRevertsZeroAddress() public {
+        vm.expectRevert(GovernanceSender.WithdrawFailed.selector);
+        sender.withdrawETH(payable(address(0)), 0.5 ether);
+    }
+
+    function testReceiveETH() public {
+        vm.deal(address(this), 1 ether);
+        (bool success,) = address(sender).call{value: 1 ether}("");
+        assertTrue(success);
+    }
+}


### PR DESCRIPTION
## Summary

- Wormhole Executor Framework を使用した Ethereum → Polygon クロスチェーンガバナンスの実装
- `GovernanceSender` (Ethereum): `ExecutorSendQuoteOnChain` によるオンチェーン手数料見積もり
- `GovernanceReceiver` (Polygon): `ExecutorReceive` + シーケンスベースリプレイ保護
- デプロイスクリプト: Polygon (Receiver + Timelock) と Ethereum (Sender)

**Flow:**
```
Ethereum Governor → Timelock(2d) → GovernanceSender
    → Wormhole Executor Framework →
        GovernanceReceiver → Polygon Timelock(1d) → PCEToken
```

## New files

| File | Description |
|------|-------------|
| `src/governance/GovernanceSender.sol` | Ethereum: Timelock → Wormhole Executor send |
| `src/governance/GovernanceReceiver.sol` | Polygon: Executor VAA receive → Timelock schedule |
| `script/DeployGovernanceSender.s.sol` | Ethereum deploy script |
| `script/DeployGovernanceReceiver.s.sol` | Polygon deploy script (Receiver + Timelock) |
| `test/GovernanceSender.t.sol` | Sender unit tests (20 tests) |
| `test/GovernanceReceiver.t.sol` | Receiver unit tests (15 tests) |
| `test/GovernanceReceiverHarness.t.sol` | Integration tests via harness (5 tests) |

## Dependencies

- Added `wormhole-solidity-sdk` (wormhole-foundation/wormhole-solidity-sdk)

## Wormhole Executor fee management

GovernanceSender pays Wormhole Executor fees from its own ETH balance via on-chain quotes:

- **Manual top-up**: Pre-fund GovernanceSender with ETH (e.g., 0.1 ETH covers hundreds of proposals)
- `quoteDeliveryPrice()` available for on-chain fee estimation
- `withdrawETH()` for reclaiming excess funds
- `sendCrossChainGovernance` is `payable` as fallback

## Test plan

- [x] `forge build` — compiles with no warnings
- [x] `forge test` — all 65 tests pass
- [ ] Deploy to testnet
- [ ] Cross-chain delivery test via Wormhole Executor testnet

---

<details>
<summary>日本語訳</summary>

## 概要

- Wormhole Executor Framework を使用した Ethereum → Polygon クロスチェーンガバナンスの実装
- `GovernanceSender` (Ethereum): `ExecutorSendQuoteOnChain` によるオンチェーン手数料見積もりを使用し、オフチェーン依存を排除
- `GovernanceReceiver` (Polygon): Wormhole SDK のシーケンスベースリプレイ保護付き `ExecutorReceive` を使用
- デプロイスクリプト: Polygon (Receiver + Timelock) と Ethereum (Sender) の両方

**フロー:**
```
Ethereum Governor → Timelock(2日) → GovernanceSender
    → Wormhole Executor Framework →
        GovernanceReceiver → Polygon Timelock(1日) → PCEToken
```

## 新規ファイル

| ファイル | 説明 |
|---------|------|
| `src/governance/GovernanceSender.sol` | Ethereum側: Timelock → Wormhole Executor 送信 |
| `src/governance/GovernanceReceiver.sol` | Polygon側: Executor VAA 受信 → Timelock スケジュール |
| `script/DeployGovernanceSender.s.sol` | Ethereum側デプロイスクリプト |
| `script/DeployGovernanceReceiver.s.sol` | Polygon側デプロイスクリプト (Receiver + Timelock) |
| `test/GovernanceSender.t.sol` | Sender 単体テスト (20テスト) |
| `test/GovernanceReceiver.t.sol` | Receiver 単体テスト (15テスト) |
| `test/GovernanceReceiverHarness.t.sol` | ハーネス経由の統合テスト (5テスト) |

## 依存関係

- `wormhole-solidity-sdk` (wormhole-foundation/wormhole-solidity-sdk) を追加

## Wormhole Executor 手数料管理

GovernanceSender はオンチェーン見積もりを使用し、自身の ETH 残高から Wormhole Executor 手数料を支払います:

- **手動補充**: GovernanceSender に事前に ETH を入金する（例: 0.1 ETH で数百回の提案をカバー可能）
- `quoteDeliveryPrice()` でオンチェーン手数料見積もりが可能
- `withdrawETH()` で余剰資金の回収が可能
- `sendCrossChainGovernance` は `payable` でフォールバック対応

## テスト計画

- [x] `forge build` — 警告なしでコンパイル成功
- [x] `forge test` — 全65テスト通過
- [ ] テストネットへのデプロイ
- [ ] Wormhole Executor テストネットでのクロスチェーン配信テスト

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)