### PR TITLE
feat: PIP-13 + PIP-15 combined upgrade (with size-fit refactor)

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -9,6 +9,10 @@
   gas_reports = ["*"]
   optimizer = true
   optimizer_runs = 200
+  # Polygon PoS raised the contract code size limit to 32 KiB via PIP-30
+  # (Ahmedabad hardfork, 2024-09-25). Foundry still defaults to EIP-170's
+  # 24,576-byte limit, so we override here to match the chain.
+  code_size_limit = 32768
   via_ir = true
   out = "out"
   script = "script"

--- a/script/upgrade.sh
+++ b/script/upgrade.sh
@@ -48,12 +48,22 @@ ERRORS=0
 validate_contract() {
     local contract="$1"
     local candidates="$2"
+    # `unsafe_allow_linked_libraries` is off by default so unintended external
+    # library linkage in future upgrades is still caught. Set it per-contract
+    # below only for contracts we deliberately link libraries into.
+    local unsafe_allow_linked_libraries="${3:-0}"
+
+    local extra_args=()
+    if [ "$unsafe_allow_linked_libraries" = "1" ]; then
+        extra_args+=("--unsafeAllow" "external-library-linking")
+    fi
 
     for candidate in $candidates; do
         if npx @openzeppelin/upgrades-core@^1.32.3 validate out/build-info \
             --contract "$contract" \
             --reference "$REF_DIR_NAME:$candidate" \
-            --referenceBuildInfoDirs "$REF_BUILD_INFO" 2>/dev/null; then
+            --referenceBuildInfoDirs "$REF_BUILD_INFO" \
+            "${extra_args[@]}" 2>/dev/null; then
             echo "  $contract: OK (reference: $candidate)"
             return 0
         fi
@@ -81,7 +91,9 @@ done
 COMMUNITY_CANDIDATES="$COMMUNITY_CANDIDATES src/PCECommunityToken.sol:PCECommunityToken"
 
 validate_contract "src/PCEToken.sol:PCEToken" "$PCE_CANDIDATES" || ERRORS=1
-validate_contract "src/PCECommunityToken.sol:PCECommunityToken" "$COMMUNITY_CANDIDATES" || ERRORS=1
+# PCECommunityToken legitimately links VoucherSystem/TokenValueOps/ArigatoCreation
+# (external libraries) since v15 — allow the OZ validator to accept that.
+validate_contract "src/PCECommunityToken.sol:PCECommunityToken" "$COMMUNITY_CANDIDATES" 1 || ERRORS=1
 
 if [ "$ERRORS" -ne 0 ]; then
     echo "ERROR: Storage layout validation failed. Aborting upgrade."

--- a/src/PCECommunityToken.sol
+++ b/src/PCECommunityToken.sol
@@ -2,24 +2,22 @@
 pragma solidity 0.8.30;
 
 import { ERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol";
-import { ERC20BurnableUpgradeable } from
-    "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC20BurnableUpgradeable.sol";
 import { Initializable } from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import { OwnableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import { ERC20PermitUpgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC20PermitUpgradeable.sol";
 import { PCEToken } from "./PCEToken.sol";
-import { Utils } from "./lib/Utils.sol";
 import { EIP3009 } from "./lib/EIP3009.sol";
 import { ECRecover } from "./lib/ECRecover.sol";
 import { TokenSetting } from "./lib/TokenSetting.sol";
 import { ExchangeAllowMethod } from "./lib/Enum.sol";
 import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
 import { VoucherSystem } from "./lib/VoucherSystem.sol";
+import { TokenValueOps } from "./lib/TokenValueOps.sol";
+import { ArigatoCreation } from "./lib/ArigatoCreation.sol";
 
 contract PCECommunityToken is
     Initializable,
     ERC20Upgradeable,
-    ERC20BurnableUpgradeable,
     OwnableUpgradeable,
     EIP3009,
     ERC20PermitUpgradeable,
@@ -101,7 +99,7 @@ contract PCECommunityToken is
         uint256 claimedAmount;
         uint256 claimedDisplayAmount;
         uint256 totalClaimCount;
-        string ipfsCid;  // Optional IPFS CID for additional metadata
+        string ipfsCid;
     }
 
     mapping(address user => AccountInfo accountInfo) private _accountInfos;
@@ -285,91 +283,31 @@ contract PCECommunityToken is
     )
         internal
     {
-        // ** Global mint limit
-        uint256 maxArigatoCreationMintToday = Math.mulDiv(midnightTotalSupply, maxIncreaseOfTotalSupplyBp, BP_BASE);
-        if (maxArigatoCreationMintToday <= 0 || maxArigatoCreationMintToday <= mintArigatoCreationToday) {
-            return;
-        }
-        uint256 remainingArigatoCreationMintToday = maxArigatoCreationMintToday - mintArigatoCreationToday;
-        uint256 remainingArigatoCreationMintTodayForGuest;
-
-        // Use storage to persist individual mint tracking across transactions
         AccountInfo storage accountInfo = _accountInfos[sender];
 
-        bool isGuest = accountInfo.firstTransactionTime == accountInfo.lastModifiedMidnightBalanceTime;
-        if (isGuest) {
-            uint256 maxArigatoCreationMintTodayForGuest = Math.mulDiv(maxArigatoCreationMintToday, 1, 10);
-            if (
-                maxArigatoCreationMintTodayForGuest <= 0
-                    || maxArigatoCreationMintTodayForGuest <= mintArigatoCreationTodayForGuest
-            ) {
-                return;
-            }
-            remainingArigatoCreationMintTodayForGuest =
-                maxArigatoCreationMintTodayForGuest - mintArigatoCreationTodayForGuest;
-        }
+        (uint256 mintAmount, bool isGuest) = ArigatoCreation.compute(
+            ArigatoCreation.AccountInfo({
+                midnightBalance: accountInfo.midnightBalance,
+                firstTransactionTime: accountInfo.firstTransactionTime,
+                lastModifiedMidnightBalanceTime: accountInfo.lastModifiedMidnightBalanceTime,
+                mintArigatoCreationToday: accountInfo.mintArigatoCreationToday
+            }),
+            ArigatoCreation.Params({
+                midnightTotalSupply: midnightTotalSupply,
+                maxIncreaseOfTotalSupplyBp: maxIncreaseOfTotalSupplyBp,
+                maxIncreaseBp: maxIncreaseBp,
+                maxUsageBp: maxUsageBp,
+                changeBp: changeBp,
+                mintArigatoCreationToday: mintArigatoCreationToday,
+                mintArigatoCreationTodayForGuest: mintArigatoCreationTodayForGuest,
+                rawAmount: rawAmount,
+                rawBalance: rawBalance,
+                messageCharacters: messageCharacters
+            })
+        );
 
-        // ** Calculation of mint amount
-        // increaseRate = (maxIncreaseRate - changeRate * abs(maxUsageRate - usageRate)) * valueOfMessageCharacter
-        uint256 usageBp = Math.mulDiv(rawAmount, BP_BASE, rawBalance);
-        uint256 absUsageBp = usageBp > maxUsageBp ? usageBp - maxUsageBp : uint256(maxUsageBp) - usageBp;
-        uint256 changeMulBp = Math.mulDiv(uint256(changeBp), absUsageBp, BP_BASE);
-        if (changeMulBp >= maxIncreaseBp) {
-            return;
-        }
-        uint256 messageLength = messageCharacters > 0 ? messageCharacters : 1;
-        uint256 messageBp =
-            messageLength > MAX_CHARACTER_LENGTH ? BP_BASE : Math.mulDiv(messageLength, BP_BASE, MAX_CHARACTER_LENGTH);
-        uint256 increaseBp = uint256(maxIncreaseBp) - Math.mulDiv(changeMulBp, messageBp, BP_BASE);
-        uint256 mintAmount = Math.mulDiv(rawAmount, increaseBp, BP_BASE);
-        if (mintAmount > remainingArigatoCreationMintToday) {
-            mintAmount = remainingArigatoCreationMintToday;
-        }
+        if (mintAmount == 0) return;
 
-        // ** Sender mint limit (with cumulative tracking via storage)
-        // mintArigatoCreationToday initial value is 1 (gas optimization), subtract 1 for actual minted
-        uint256 actualMinted = accountInfo.mintArigatoCreationToday > 0
-            ? accountInfo.mintArigatoCreationToday - 1
-            : 0;
-
-        if (!isGuest) {
-            uint256 maxArigatoCreationMintTodayForSender =
-                Math.mulDiv(maxArigatoCreationMintToday, accountInfo.midnightBalance, midnightTotalSupply);
-            if (maxArigatoCreationMintTodayForSender <= 0) {
-                return;
-            }
-            // Check cumulative sender limit
-            uint256 remainingSenderCap = maxArigatoCreationMintTodayForSender > actualMinted
-                ? maxArigatoCreationMintTodayForSender - actualMinted
-                : 0;
-            if (remainingSenderCap == 0) {
-                return;
-            }
-            if (mintAmount > remainingSenderCap) {
-                mintAmount = remainingSenderCap;
-            }
-        } else {
-            // Guest can mint only 1% of maxArigatoCreationMintToday
-            if (mintAmount > remainingArigatoCreationMintTodayForGuest) {
-                mintAmount = remainingArigatoCreationMintTodayForGuest;
-            }
-            uint256 maxArigatoCreationMintTodayForGuestSender = Math.mulDiv(maxArigatoCreationMintToday, 1, 100);
-            if (maxArigatoCreationMintTodayForGuestSender <= 0) {
-                return;
-            }
-            // Check cumulative guest sender limit
-            uint256 remainingGuestSenderCap = maxArigatoCreationMintTodayForGuestSender > actualMinted
-                ? maxArigatoCreationMintTodayForGuestSender - actualMinted
-                : 0;
-            if (remainingGuestSenderCap == 0) {
-                return;
-            }
-            if (mintAmount > remainingGuestSenderCap) {
-                mintAmount = remainingGuestSenderCap;
-            }
-        }
-
-        // ** Execute mint
         _mint(sender, mintAmount);
         unchecked {
             accountInfo.mintArigatoCreationToday += mintAmount;
@@ -386,9 +324,7 @@ contract PCECommunityToken is
         uint256 rawBalance = super.balanceOf(_msgSender());
         uint256 rawAmount = displayBalanceToRawBalance(displayAmount);
         bool ret = super.transfer(receiver, rawAmount);
-
         _mintArigatoCreation(_msgSender(), rawAmount, rawBalance, 1);
-
         return ret;
     }
 
@@ -397,11 +333,8 @@ contract PCECommunityToken is
         uint256 rawBalance = super.balanceOf(_msgSender());
         uint256 rawAmount = displayBalanceToRawBalance(displayAmount);
         bool ret = super.transfer(receiver, rawAmount);
-
         _mintArigatoCreation(_msgSender(), rawAmount, rawBalance, messageCount);
-
         emit TransferWithMessageCount(_msgSender(), receiver, displayAmount, messageCount);
-
         return ret;
     }
 
@@ -427,9 +360,7 @@ contract PCECommunityToken is
         uint256 rawBalance = super.balanceOf(sender);
         uint256 rawAmount = displayBalanceToRawBalance(displayBalance);
         bool ret = super.transferFrom(sender, receiver, rawAmount);
-
         _mintArigatoCreation(sender, rawAmount, rawBalance, 1);
-
         return ret;
     }
 
@@ -438,11 +369,8 @@ contract PCECommunityToken is
         uint256 rawBalance = super.balanceOf(sender);
         uint256 rawAmount = displayBalanceToRawBalance(displayBalance);
         bool ret = super.transferFrom(sender, receiver, rawAmount);
-
         _mintArigatoCreation(sender, rawAmount, rawBalance, messageCount);
-
         emit TransferWithMessageCount(sender, receiver, displayBalance, messageCount);
-
         return ret;
     }
 
@@ -462,14 +390,16 @@ contract PCECommunityToken is
         _mint(to, displayBalanceToRawBalance(displayBalance));
     }
 
-    function burn(uint256 displayBalance) public override {
+    function burn(uint256 displayBalance) public {
         updateFactorIfNeeded();
-        super.burn(displayBalanceToRawBalance(displayBalance));
+        _burn(_msgSender(), displayBalanceToRawBalance(displayBalance));
     }
 
-    function burnFrom(address account, uint256 displayBalance) public override {
+    function burnFrom(address account, uint256 displayBalance) public {
         updateFactorIfNeeded();
-        super.burnFrom(account, displayBalanceToRawBalance(displayBalance));
+        uint256 rawBalance = displayBalanceToRawBalance(displayBalance);
+        _spendAllowance(account, _msgSender(), rawBalance);
+        _burn(account, rawBalance);
     }
 
     function burnByPCEToken(address account, uint256 displayBalance) external {
@@ -490,58 +420,22 @@ contract PCECommunityToken is
         return (endDay - startDay) >= intervalDays;
     }
 
-    function _isAllowExchange(bool isIncome, address tokenAddress) private view returns (bool) {
-        ExchangeAllowMethod allowMethod = isIncome ? incomeExchangeAllowMethod : outgoExchangeAllowMethod;
-        address[] memory targetTokens = isIncome ? incomeTargetTokens : outgoTargetTokens;
-        if (allowMethod == ExchangeAllowMethod.None) {
-            return false;
-        } else if (allowMethod == ExchangeAllowMethod.All) {
-            return true;
-        } else if (allowMethod == ExchangeAllowMethod.Include) {
-            for (uint256 i = 0; i < targetTokens.length;) {
-                if (targetTokens[i] == tokenAddress) {
-                    return true;
-                }
-                unchecked {
-                    i++;
-                }
-            }
-            return false;
-        } else if (allowMethod == ExchangeAllowMethod.Exclude) {
-            for (uint256 i = 0; i < targetTokens.length;) {
-                if (targetTokens[i] == tokenAddress) {
-                    return false;
-                }
-                unchecked {
-                    i++;
-                }
-            }
-            return true;
-        } else {
-            revert("Invalid exchangeAllowMethod");
-        }
-    }
-
     function isAllowOutgoExchange(address tokenAddress) public view returns (bool) {
-        return _isAllowExchange(false, tokenAddress);
+        return TokenValueOps.isAllowExchange(
+            false, tokenAddress, incomeExchangeAllowMethod, outgoExchangeAllowMethod, incomeTargetTokens, outgoTargetTokens
+        );
     }
 
     function isAllowIncomeExchange(address tokenAddress) public view returns (bool) {
-        return _isAllowExchange(true, tokenAddress);
+        return TokenValueOps.isAllowExchange(
+            true, tokenAddress, incomeExchangeAllowMethod, outgoExchangeAllowMethod, incomeTargetTokens, outgoTargetTokens
+        );
     }
 
     function swapTokens(address toTokenAddress, uint256 amountToSwap) public {
         address sender = _msgSender();
         updateFactorIfNeeded();
-        PCEToken pceToken = PCEToken(pceAddress);
-        pceToken.updateFactorIfNeeded();
-
-        Utils.LocalToken memory fromToken = pceToken.getLocalToken(address(this));
-        require(fromToken.isExists, "From token not found");
-
-        Utils.LocalToken memory toToken = pceToken.getLocalToken(toTokenAddress);
-        require(toToken.isExists, "Target token not found");
-
+        PCEToken(pceAddress).updateFactorIfNeeded();
         PCECommunityToken to = PCECommunityToken(toTokenAddress);
         to.updateFactorIfNeeded();
 
@@ -549,37 +443,57 @@ contract PCECommunityToken is
         require(isAllowOutgoExchange(toTokenAddress), "Outgo exchange not allowed");
         require(to.isAllowIncomeExchange(address(this)), "Income exchange not allowed");
 
-        uint256 targetTokenAmount = Math.mulDiv(
-            Math.mulDiv(
-                Math.mulDiv(amountToSwap, 10 ** 18, fromToken.exchangeRate),
-                pceToken.getCurrentFactor(),
-                getCurrentFactor()
-            ),
-            Math.mulDiv(toToken.exchangeRate, to.getCurrentFactor(), INITIAL_FACTOR),
-            pceToken.getCurrentFactor()
+        uint256 targetTokenAmount = TokenValueOps.computeSwapAmount(
+            pceAddress, address(this), toTokenAddress, amountToSwap, getCurrentFactor(), to.getCurrentFactor()
         );
-
-        require(targetTokenAmount > 0, "Invalid amount to swap");
-
         super._burn(sender, displayBalanceToRawBalance(amountToSwap));
         to.mint(sender, targetTokenAmount);
     }
 
     function getMetaTransactionFee() public view returns (uint256) {
-        PCEToken pceToken = PCEToken(pceAddress);
-        uint256 pceTokenFee = pceToken.getMetaTransactionFee();
-        uint256 rate = pceToken.getSwapRate(address(this));
-        return Math.mulDiv(pceTokenFee, rate, 2**96);
+        return getMetaTransactionFeeWithBaseFee(block.basefee);
     }
 
     function getMetaTransactionFeeWithBaseFee(uint256 _baseFee) public view returns (uint256) {
         PCEToken pceToken = PCEToken(pceAddress);
-        uint256 pceTokenFee = pceToken.getMetaTransactionFeeWithBaseFee(_baseFee);
-        uint256 rate = pceToken.getSwapRate(address(this));
-        return Math.mulDiv(pceTokenFee, rate, 2**96);
+        return Math.mulDiv(
+            pceToken.getMetaTransactionFeeWithBaseFee(_baseFee),
+            pceToken.getSwapRate(address(this)),
+            2**96
+        );
+    }
+
+    function _digest(bytes memory data) internal view returns (bytes32) {
+        return keccak256(abi.encodePacked("\x19\x01", this.DOMAIN_SEPARATOR(), keccak256(data)));
+    }
+
+    function _useAuthorization(
+        address authorizer,
+        uint256 validAfter,
+        uint256 validBefore,
+        bytes32 nonce,
+        bytes32 digest,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    )
+        internal
+    {
+        require(block.timestamp > validAfter, "Not yet valid");
+        require(block.timestamp < validBefore, "Authorization expired");
+        require(!_authorizationStates[authorizer][nonce], "Authorization used");
+        require(ECRecover.recover(digest, v, r, s) == authorizer, "Invalid signature");
+        _authorizationStates[authorizer][nonce] = true;
+        emit AuthorizationUsed(authorizer, nonce);
     }
 
     function _collectFeeAsPCE(address from, address relayer, uint256 displayFee) internal returns (uint256) {
+        // Preserve the pre-PIP-13 zero-fee behaviour: if the configured meta-tx
+        // fee is zero there is nothing to collect and we must skip the swap so
+        // the downstream `swapFeeFromLocalToken` non-zero check doesn't brick
+        // meta-tx / voucher flows.
+        if (displayFee == 0) return 0;
+
         uint256 rawFee = displayBalanceToRawBalance(displayFee);
         _burn(from, rawFee);
         PCEToken pceToken = PCEToken(pceAddress);
@@ -599,7 +513,6 @@ contract PCECommunityToken is
         uint256 rawAmount = displayBalanceToRawBalance(displayAmount);
         uint256 displayFee = getMetaTransactionFee();
 
-        // Prevent zero-amount transfer that only charges fee
         require(rawAmount > 0, "Amount must be greater than zero");
 
         _transferWithAuthorization(from, to, displayAmount, validAfter, validBefore, nonce, v, r, s, rawAmount);
@@ -616,7 +529,6 @@ contract PCECommunityToken is
     {
         updateFactorIfNeeded();
 
-        // Input address validation
         require(spender != address(0), "Invalid spender address");
         require(from != address(0), "Invalid from address");
         require(to != address(0), "Invalid to address");
@@ -626,47 +538,28 @@ contract PCECommunityToken is
         uint256 displayFee = getMetaTransactionFee();
         uint256 rawFee = displayBalanceToRawBalance(displayFee);
 
-        // Prevent zero-amount fee drain attack
         require(rawAmount > 0, "Amount must be greater than zero");
-
-        require(block.timestamp > validAfter, "Not yet valid");
-        require(block.timestamp < validBefore, "Authorization expired");
-        require(!_authorizationStates[spender][nonce], "Authorization used");
         require(rawBalance >= (rawAmount + rawFee), "Insufficient balance");
-        // Include fee in allowance check
         require(
             _infinityApproveFlags[from][spender]
                 || super.allowance(from, spender) >= (rawAmount + rawFee),
             "Insufficient allowance"
         );
 
-        bytes memory data = abi.encode(
-            TRANSFER_FROM_WITH_AUTHORIZATION_TYPEHASH,
-            spender,
-            from,
-            to,
-            displayAmount,
+        _useAuthorization(spender,
             validAfter,
             validBefore,
-            nonce
-        );
-        bytes32 digest = keccak256(abi.encodePacked(
-            "\x19\x01",
-            this.DOMAIN_SEPARATOR(),
-            keccak256(data)
-        ));
-
-        // Use ECRecover.recover for address(0) guard
-        require(
-            ECRecover.recover(digest, v, r, s) == spender,
-            "Invalid signature"
+            nonce,
+            _digest(abi.encode(
+                TRANSFER_FROM_WITH_AUTHORIZATION_TYPEHASH,
+                spender, from, to, displayAmount, validAfter, validBefore, nonce
+            )),
+            v, r, s
         );
 
-        _authorizationStates[spender][nonce] = true;
-        emit AuthorizationUsed(spender, nonce);
-
-        // Include fee in allowance spend
-        _spendAllowance(from, spender, rawAmount + rawFee);
+        if (!_infinityApproveFlags[from][spender]) {
+            _spendAllowance(from, spender, rawAmount + rawFee);
+        }
         super._transfer(from, to, rawAmount);
         _collectFeeAsPCE(from, _msgSender(), displayFee);
 
@@ -682,43 +575,23 @@ contract PCECommunityToken is
         uint256 rawBalance = super.balanceOf(from);
         uint256 rawAmount = displayBalanceToRawBalance(displayAmount);
         uint256 displayFee = getMetaTransactionFee();
-        uint256 rawFee = displayBalanceToRawBalance(displayFee);
 
-        // Prevent zero-amount transfer that only charges fee
         require(rawAmount > 0, "Amount must be greater than zero");
 
-        require(block.timestamp > validAfter, "Not yet valid");
-        require(block.timestamp < validBefore, "Authorization expired");
-        require(!_authorizationStates[from][nonce], "Authorization used");
-
-        bytes memory data = abi.encode(
-            TRANSFER_WITH_AUTHORIZATION_WITH_MESSAGE_COUNT_TYPEHASH,
-            from,
-            to,
-            displayAmount,
+        _useAuthorization(from,
             validAfter,
             validBefore,
             nonce,
-            messageCount
+            _digest(abi.encode(
+                TRANSFER_WITH_AUTHORIZATION_WITH_MESSAGE_COUNT_TYPEHASH,
+                from, to, displayAmount, validAfter, validBefore, nonce, messageCount
+            )),
+            v, r, s
         );
-        bytes32 digest = keccak256(abi.encodePacked(
-            "\x19\x01",
-            this.DOMAIN_SEPARATOR(),
-            keccak256(data)
-        ));
-
-        require(
-            ECRecover.recover(digest, v, r, s) == from,
-            "Invalid signature"
-        );
-
-        _authorizationStates[from][nonce] = true;
-        emit AuthorizationUsed(from, nonce);
 
         super._transfer(from, to, rawAmount);
-        super._transfer(from, _msgSender(), rawFee);
+        _collectFeeAsPCE(from, _msgSender(), displayFee);
 
-        emit MetaTransactionFeeCollected(from, _msgSender(), displayFee, rawFee);
         emit TransferWithMessageCount(from, to, displayAmount, messageCount);
 
         _mintArigatoCreation(from, rawAmount, rawBalance, messageCount);
@@ -731,7 +604,6 @@ contract PCECommunityToken is
     {
         updateFactorIfNeeded();
 
-        // Input address validation
         require(spender != address(0), "Invalid spender address");
         require(from != address(0), "Invalid from address");
         require(to != address(0), "Invalid to address");
@@ -741,52 +613,31 @@ contract PCECommunityToken is
         uint256 displayFee = getMetaTransactionFee();
         uint256 rawFee = displayBalanceToRawBalance(displayFee);
 
-        // Prevent zero-amount fee drain attack
         require(rawAmount > 0, "Amount must be greater than zero");
-
-        require(block.timestamp > validAfter, "Not yet valid");
-        require(block.timestamp < validBefore, "Authorization expired");
-        require(!_authorizationStates[spender][nonce], "Authorization used");
         require(rawBalance >= (rawAmount + rawFee), "Insufficient balance");
-        // Include fee in allowance check
         require(
             _infinityApproveFlags[from][spender]
                 || super.allowance(from, spender) >= (rawAmount + rawFee),
             "Insufficient allowance"
         );
 
-        bytes memory data = abi.encode(
-            TRANSFER_FROM_WITH_AUTHORIZATION_WITH_MESSAGE_COUNT_TYPEHASH,
-            spender,
-            from,
-            to,
-            displayAmount,
+        _useAuthorization(spender,
             validAfter,
             validBefore,
             nonce,
-            messageCount
-        );
-        bytes32 digest = keccak256(abi.encodePacked(
-            "\x19\x01",
-            this.DOMAIN_SEPARATOR(),
-            keccak256(data)
-        ));
-
-        // Use ECRecover.recover for address(0) guard
-        require(
-            ECRecover.recover(digest, v, r, s) == spender,
-            "Invalid signature"
+            _digest(abi.encode(
+                TRANSFER_FROM_WITH_AUTHORIZATION_WITH_MESSAGE_COUNT_TYPEHASH,
+                spender, from, to, displayAmount, validAfter, validBefore, nonce, messageCount
+            )),
+            v, r, s
         );
 
-        _authorizationStates[spender][nonce] = true;
-        emit AuthorizationUsed(spender, nonce);
-
-        // Include fee in allowance spend
-        _spendAllowance(from, spender, rawAmount + rawFee);
+        if (!_infinityApproveFlags[from][spender]) {
+            _spendAllowance(from, spender, rawAmount + rawFee);
+        }
         super._transfer(from, to, rawAmount);
-        super._transfer(from, _msgSender(), rawFee);
+        _collectFeeAsPCE(from, _msgSender(), displayFee);
 
-        emit MetaTransactionFeeCollected(from, _msgSender(), displayFee, rawFee);
         emit TransferWithMessageCount(from, to, displayAmount, messageCount);
 
         _mintArigatoCreation(from, rawAmount, rawBalance, messageCount);
@@ -875,50 +726,51 @@ contract PCECommunityToken is
     {
         updateFactorIfNeeded();
 
-        // Input address validation
         require(owner != address(0), "Invalid owner address");
         require(spender != address(0), "Invalid spender address");
 
         uint256 displayFee = getMetaTransactionFee();
         uint256 rawFee = displayBalanceToRawBalance(displayFee);
-
-        require(block.timestamp > validAfter, "Not yet valid");
-        require(block.timestamp < validBefore, "Authorization expired");
-        require(!_authorizationStates[owner][nonce], "Authorization used");
         require(super.balanceOf(owner) >= rawFee, "Insufficient balance");
 
-        bytes memory data = abi.encode(
-            SET_INFINITY_APPROVE_FLAG_WITH_AUTHORIZATION_TYPEHASH,
-            owner,
-            spender,
-            flag,
+        _useAuthorization(owner,
             validAfter,
             validBefore,
-            nonce
+            nonce,
+            _digest(abi.encode(
+                SET_INFINITY_APPROVE_FLAG_WITH_AUTHORIZATION_TYPEHASH,
+                owner, spender, flag, validAfter, validBefore, nonce
+            )),
+            v, r, s
         );
-        bytes32 digest = keccak256(abi.encodePacked(
-            "\x19\x01",
-            this.DOMAIN_SEPARATOR(),
-            keccak256(data)
-        ));
-
-        // Use ECRecover.recover for address(0) guard
-        require(
-            ECRecover.recover(digest, v, r, s) == owner,
-            "Invalid signature"
-        );
-
-        _authorizationStates[owner][nonce] = true;
-        emit AuthorizationUsed(owner, nonce);
 
         _infinityApproveFlags[owner][spender] = flag;
         emit InfinityApproveFlagSet(owner, spender, flag);
 
-        // Collect meta transaction fee from owner
         _collectFeeAsPCE(owner, _msgSender(), displayFee);
     }
 
-    // Voucher functions
+    // ====================================================================
+    // Voucher functions (delegated to VoucherSystem library)
+    //
+    // Heavy logic lives in VoucherSystem.sol as public (linked) functions;
+    // `__libTransfer` / `__libCollectFeeAsPCE` below are self-call hooks the
+    // library uses to reach internal ERC20 transfers and fee collection.
+    // ====================================================================
+
+    modifier onlySelf() {
+        require(msg.sender == address(this), "Only self");
+        _;
+    }
+
+    function __libTransfer(address from, address to, uint256 rawAmount) external onlySelf {
+        super._transfer(from, to, rawAmount);
+    }
+
+    function __libCollectFeeAsPCE(address from, address relayer, uint256 displayFee) external onlySelf {
+        _collectFeeAsPCE(from, relayer, displayFee);
+    }
+
     function registerVoucherIssuance(
         string memory issuanceId,
         string memory _name,
@@ -933,36 +785,23 @@ contract PCECommunityToken is
     )
         external
     {
-        uint256 initialFundsRawAmount = displayBalanceToRawBalance(_initialFunds);
-        require(super.balanceOf(_msgSender()) >= initialFundsRawAmount, "Insufficient balance");
-
-        VoucherSystem.registerIssuance(
+        VoucherSystem.registerIssuanceWithLock(
             _voucherStorage,
             issuanceId,
             _name,
             _amountPerClaim,
             _countLimitPerUser,
             _totalAmountLimit,
-            initialFundsRawAmount,
+            _initialFunds,
             _startTime,
             _endTime,
             _merkleRoot,
-            _msgSender(),
             _ipfsCid
         );
-
-        // Lock tokens from issuer
-        super._transfer(_msgSender(), address(this), initialFundsRawAmount);
     }
 
     function claimVoucher(string memory issuanceId, string memory code, bytes32[] calldata proof) external {
-        VoucherSystem.VoucherIssuance memory issuance = VoucherSystem.getIssuance(_voucherStorage, issuanceId);
-        uint256 rawClaimAmount = displayBalanceToRawBalance(issuance.amountPerClaim);
-
-        VoucherSystem.claim(_voucherStorage, issuanceId, code, proof, _msgSender(), rawClaimAmount);
-
-        // Transfer tokens from contract to claimer
-        super._transfer(address(this), _msgSender(), rawClaimAmount);
+        VoucherSystem.claimAndTransfer(_voucherStorage, issuanceId, code, proof);
     }
 
     function claimVoucherWithAuthorization(
@@ -980,52 +819,22 @@ contract PCECommunityToken is
         external
     {
         updateFactorIfNeeded();
-
-        // Input address validation
         require(claimer != address(0), "Invalid claimer address");
-
-        uint256 displayFee = getMetaTransactionFee();
-        uint256 rawFee = displayBalanceToRawBalance(displayFee);
-
-        require(block.timestamp > validAfter, "Not yet valid");
-        require(block.timestamp < validBefore, "Authorization expired");
-        require(!_authorizationStates[claimer][nonce], "Authorization used");
-
-        bytes memory data = abi.encode(
-            CLAIM_WITH_AUTHORIZATION_TYPEHASH,
+        VoucherSystem.claimWithAuthorizationAndTransfer(
+            _voucherStorage,
+            _authorizationStates,
             claimer,
-            keccak256(bytes(issuanceId)),
-            keccak256(bytes(code)),
+            issuanceId,
+            code,
+            proof,
             validAfter,
             validBefore,
-            nonce
+            nonce,
+            v,
+            r,
+            s,
+            _msgSender()
         );
-        bytes32 digest = keccak256(abi.encodePacked("\x19\x01", this.DOMAIN_SEPARATOR(), keccak256(data)));
-
-        // Use ECRecover.recover for address(0) guard
-        require(ECRecover.recover(digest, v, r, s) == claimer, "Invalid signature");
-
-        _authorizationStates[claimer][nonce] = true;
-        emit AuthorizationUsed(claimer, nonce);
-
-        // Get claim amount and convert to raw balance
-        VoucherSystem.VoucherIssuance memory issuance = VoucherSystem.getIssuance(_voucherStorage, issuanceId);
-        uint256 rawClaimAmount = displayBalanceToRawBalance(issuance.amountPerClaim);
-
-        // Check if claim amount is greater than meta transaction fee
-        require(rawClaimAmount > rawFee, "Claim amount must be greater than fee");
-
-        // Claim from voucher
-        VoucherSystem.claim(_voucherStorage, issuanceId, code, proof, claimer, rawClaimAmount);
-
-        // Calculate amount after deducting fee
-        uint256 amountAfterFee = rawClaimAmount - rawFee;
-
-        // Transfer amount after fee to claimer
-        super._transfer(address(this), claimer, amountAfterFee);
-
-        // Collect meta transaction fee from claimed amount (swap to PCE for relayer)
-        _collectFeeAsPCE(address(this), _msgSender(), displayFee);
     }
 
     function getVoucherIssuanceInfo(string memory issuanceId)
@@ -1076,31 +885,15 @@ contract PCECommunityToken is
     }
 
     function addVoucherFunds(string memory issuanceId, uint256 _amount) external {
-        uint256 rawAmount = displayBalanceToRawBalance(_amount);
-        require(super.balanceOf(_msgSender()) >= rawAmount, "Insufficient balance");
-
-        VoucherSystem.addFunds(_voucherStorage, issuanceId, rawAmount, _msgSender());
-
-        // Transfer tokens from sender to contract
-        super._transfer(_msgSender(), address(this), rawAmount);
+        VoucherSystem.addFundsWithTransfer(_voucherStorage, issuanceId, _amount);
     }
 
     function withdrawVoucherFunds(string memory issuanceId, uint256 _amount) external {
-        uint256 rawAmount = displayBalanceToRawBalance(_amount);
-
-        uint256 withdrawnRawAmount = VoucherSystem.withdrawFunds(_voucherStorage, issuanceId, rawAmount, _msgSender());
-
-        // Transfer tokens from contract to sender
-        super._transfer(address(this), _msgSender(), withdrawnRawAmount);
+        VoucherSystem.withdrawFundsWithTransfer(_voucherStorage, issuanceId, _amount);
     }
 
     function terminateVoucherIssuance(string memory issuanceId) external {
-        uint256 remainingRawAmount = VoucherSystem.terminateIssuance(_voucherStorage, issuanceId, _msgSender());
-
-        // Transfer remaining tokens from contract to sender
-        if (remainingRawAmount > 0) {
-            super._transfer(address(this), _msgSender(), remainingRawAmount);
-        }
+        VoucherSystem.terminateWithRefund(_voucherStorage, issuanceId);
     }
 
     function setTokenSettings(
@@ -1145,61 +938,28 @@ contract PCECommunityToken is
     }
 
     function initializeTreasury(address wallet) external onlyOwner {
-        require(treasuryWallet == address(0), "Already initialized");
-        require(wallet != address(0), "Invalid wallet address");
-        treasuryWallet = wallet;
-        rebaseFactor = INITIAL_FACTOR;
-        _roles[RATE_MANAGER_ROLE][_msgSender()] = true;
-        emit TreasuryWalletSet(wallet);
-        emit RateManagerRoleGranted(_msgSender());
+        (treasuryWallet, rebaseFactor) =
+            TokenValueOps.initializeTreasury(treasuryWallet, wallet, _msgSender(), _roles, RATE_MANAGER_ROLE);
     }
 
     function setTreasuryWallet(address wallet) external onlyRateManager {
-        require(wallet != address(0), "Invalid wallet address");
-        treasuryWallet = wallet;
-        emit TreasuryWalletSet(wallet);
+        treasuryWallet = TokenValueOps.setTreasuryWallet(wallet);
     }
 
     function increaseTokenValue(uint256 pceAmount) external onlyRateManager {
-        require(pceAmount > 0, "Amount must be > 0");
-        PCEToken pceToken = PCEToken(pceAddress);
-        uint256 oldExchangeRate = pceToken.getExchangeRate(address(this));
-        pceToken.addReserve(address(this), pceAmount, treasuryWallet);
-        uint256 newExchangeRate = pceToken.getExchangeRate(address(this));
-        emit TokenValueIncreased(pceAmount, oldExchangeRate, newExchangeRate);
+        TokenValueOps.increaseTokenValue(pceAmount, pceAddress, address(this), treasuryWallet);
     }
 
     function splitToken(uint256 mintAmount) external onlyRateManager {
-        require(mintAmount > 0, "Amount must be > 0");
-
-        uint256 oldRebaseFactor = rebaseFactor;
-        uint256 currentTotalDisplay = totalSupply();
-        require(currentTotalDisplay > 0, "No supply to split");
-
-        PCEToken pceToken = PCEToken(pceAddress);
-        uint256 oldExchangeRate = pceToken.getExchangeRate(address(this));
-
-        // Adjust rebase factor: newFactor = oldFactor * (totalDisplay + mintAmount) / totalDisplay
-        rebaseFactor = Math.mulDiv(oldRebaseFactor, currentTotalDisplay + mintAmount, currentTotalDisplay);
-
-        // Adjust exchange rate: newRate = oldRate * newRebaseFactor / oldRebaseFactor
-        uint256 newRate = Math.mulDiv(oldExchangeRate, rebaseFactor, oldRebaseFactor);
-        pceToken.adjustExchangeRate(address(this), newRate);
-
-        uint256 newExchangeRate = pceToken.getExchangeRate(address(this));
-        emit TokenSplit(mintAmount, oldExchangeRate, newExchangeRate, oldRebaseFactor, rebaseFactor);
+        rebaseFactor = TokenValueOps.splitToken(mintAmount, totalSupply(), rebaseFactor, pceAddress, address(this));
     }
 
     function grantRateManagerRole(address account) external onlyRateManager {
-        require(account != address(0), "Invalid account address");
-        _roles[RATE_MANAGER_ROLE][account] = true;
-        emit RateManagerRoleGranted(account);
+        TokenValueOps.grantRateManagerRole(account, _roles, RATE_MANAGER_ROLE);
     }
 
     function revokeRateManagerRole(address account) external onlyRateManager {
-        require(account != address(0), "Invalid account address");
-        _roles[RATE_MANAGER_ROLE][account] = false;
-        emit RateManagerRoleRevoked(account);
+        TokenValueOps.revokeRateManagerRole(account, _roles, RATE_MANAGER_ROLE);
     }
 
     function version() public pure returns (string memory) {

--- a/src/PCECommunityToken.sol
+++ b/src/PCECommunityToken.sol
@@ -56,6 +56,24 @@ contract PCECommunityToken is
     bytes32 public constant CLAIM_WITH_AUTHORIZATION_TYPEHASH =
         0x0b6aae1d90e3a85a25061f4c51e754a9cce2a86cf2f51fb09be1001de8fb7c0a;
 
+    /*
+        keccak256(
+            "TransferWithAuthorizationWithMessageCount(address from,address to,uint256 value,
+                uint256 validAfter,uint256 validBefore,bytes32 nonce,uint256 messageCount)"
+        )
+    */
+    bytes32 public constant TRANSFER_WITH_AUTHORIZATION_WITH_MESSAGE_COUNT_TYPEHASH =
+        0xbd5d42154bfea4ab9874186856d7f4024f087ed1d032940fc2bb1072cf855cfe;
+
+    /*
+        keccak256(
+            "TransferFromWithAuthorizationWithMessageCount(address spender,address from,address to,uint256 value,
+                uint256 validAfter,uint256 validBefore,bytes32 nonce,uint256 messageCount)"
+        )
+    */
+    bytes32 public constant TRANSFER_FROM_WITH_AUTHORIZATION_WITH_MESSAGE_COUNT_TYPEHASH =
+        0x13fcc8397683033a52e999616037110db35913dff276c6b4e8766d1acf918b9c;
+
     address public pceAddress;
     uint256 public initialFactor;
     uint256 public epochTime;
@@ -101,6 +119,7 @@ contract PCECommunityToken is
     event MintArigatoCreation(address indexed to, uint256 displayAmount, uint256 rawAmount);
     event MetaTransactionFeeCollected(address indexed from, address indexed to, uint256 displayFee, uint256 rawFee);
     event InfinityApproveFlagSet(address indexed owner, address indexed spender, bool flag);
+    event TransferWithMessageCount(address indexed from, address indexed to, uint256 displayAmount, uint256 messageCount);
 
     function initialize(string memory name, string memory symbol, uint256 _initialFactor) public initializer {
         require(_initialFactor > 0, "Initial factor must be > 0");
@@ -353,6 +372,19 @@ contract PCECommunityToken is
         return ret;
     }
 
+    function transferWithMessageCount(address receiver, uint256 displayAmount, uint256 messageCount) public returns (bool) {
+        updateFactorIfNeeded();
+        uint256 rawBalance = super.balanceOf(_msgSender());
+        uint256 rawAmount = displayBalanceToRawBalance(displayAmount);
+        bool ret = super.transfer(receiver, rawAmount);
+
+        _mintArigatoCreation(_msgSender(), rawAmount, rawBalance, messageCount);
+
+        emit TransferWithMessageCount(_msgSender(), receiver, displayAmount, messageCount);
+
+        return ret;
+    }
+
     function _spendAllowance(address owner, address spender, uint256 value) internal virtual override {
         // Check infinity approve flag first
         if (_infinityApproveFlags[owner][spender]) {
@@ -377,6 +409,19 @@ contract PCECommunityToken is
         bool ret = super.transferFrom(sender, receiver, rawAmount);
 
         _mintArigatoCreation(sender, rawAmount, rawBalance, 1);
+
+        return ret;
+    }
+
+    function transferFromWithMessageCount(address sender, address receiver, uint256 displayBalance, uint256 messageCount) public returns (bool) {
+        updateFactorIfNeeded();
+        uint256 rawBalance = super.balanceOf(sender);
+        uint256 rawAmount = displayBalanceToRawBalance(displayBalance);
+        bool ret = super.transferFrom(sender, receiver, rawAmount);
+
+        _mintArigatoCreation(sender, rawAmount, rawBalance, messageCount);
+
+        emit TransferWithMessageCount(sender, receiver, displayBalance, messageCount);
 
         return ret;
     }
@@ -601,6 +646,125 @@ contract PCECommunityToken is
 
         emit MetaTransactionFeeCollected(from, _msgSender(), displayFee, rawFee);
         _mintArigatoCreation(from, rawAmount, rawBalance, 1);
+    }
+
+    function transferWithAuthorizationWithMessageCount(
+        address from, address to, uint256 displayAmount, uint256 validAfter, uint256 validBefore, bytes32 nonce, uint8 v, bytes32 r, bytes32 s, uint256 messageCount
+    )
+        public
+    {
+        updateFactorIfNeeded();
+        uint256 rawBalance = super.balanceOf(from);
+        uint256 rawAmount = displayBalanceToRawBalance(displayAmount);
+        uint256 displayFee = getMetaTransactionFee();
+        uint256 rawFee = displayBalanceToRawBalance(displayFee);
+
+        // Prevent zero-amount transfer that only charges fee
+        require(rawAmount > 0, "Amount must be greater than zero");
+
+        require(block.timestamp > validAfter, "Not yet valid");
+        require(block.timestamp < validBefore, "Authorization expired");
+        require(!_authorizationStates[from][nonce], "Authorization used");
+
+        bytes memory data = abi.encode(
+            TRANSFER_WITH_AUTHORIZATION_WITH_MESSAGE_COUNT_TYPEHASH,
+            from,
+            to,
+            displayAmount,
+            validAfter,
+            validBefore,
+            nonce,
+            messageCount
+        );
+        bytes32 digest = keccak256(abi.encodePacked(
+            "\x19\x01",
+            this.DOMAIN_SEPARATOR(),
+            keccak256(data)
+        ));
+
+        require(
+            ECRecover.recover(digest, v, r, s) == from,
+            "Invalid signature"
+        );
+
+        _authorizationStates[from][nonce] = true;
+        emit AuthorizationUsed(from, nonce);
+
+        super._transfer(from, to, rawAmount);
+        super._transfer(from, _msgSender(), rawFee);
+
+        emit MetaTransactionFeeCollected(from, _msgSender(), displayFee, rawFee);
+        emit TransferWithMessageCount(from, to, displayAmount, messageCount);
+
+        _mintArigatoCreation(from, rawAmount, rawBalance, messageCount);
+    }
+
+    function transferFromWithAuthorizationWithMessageCount(
+        address spender, address from, address to, uint256 displayAmount, uint256 validAfter, uint256 validBefore, bytes32 nonce, uint8 v, bytes32 r, bytes32 s, uint256 messageCount
+    )
+        public
+    {
+        updateFactorIfNeeded();
+
+        // Input address validation
+        require(spender != address(0), "Invalid spender address");
+        require(from != address(0), "Invalid from address");
+        require(to != address(0), "Invalid to address");
+
+        uint256 rawBalance = super.balanceOf(from);
+        uint256 rawAmount = displayBalanceToRawBalance(displayAmount);
+        uint256 displayFee = getMetaTransactionFee();
+        uint256 rawFee = displayBalanceToRawBalance(displayFee);
+
+        // Prevent zero-amount fee drain attack
+        require(rawAmount > 0, "Amount must be greater than zero");
+
+        require(block.timestamp > validAfter, "Not yet valid");
+        require(block.timestamp < validBefore, "Authorization expired");
+        require(!_authorizationStates[spender][nonce], "Authorization used");
+        require(rawBalance >= (rawAmount + rawFee), "Insufficient balance");
+        // Include fee in allowance check
+        require(
+            _infinityApproveFlags[from][spender]
+                || super.allowance(from, spender) >= (rawAmount + rawFee),
+            "Insufficient allowance"
+        );
+
+        bytes memory data = abi.encode(
+            TRANSFER_FROM_WITH_AUTHORIZATION_WITH_MESSAGE_COUNT_TYPEHASH,
+            spender,
+            from,
+            to,
+            displayAmount,
+            validAfter,
+            validBefore,
+            nonce,
+            messageCount
+        );
+        bytes32 digest = keccak256(abi.encodePacked(
+            "\x19\x01",
+            this.DOMAIN_SEPARATOR(),
+            keccak256(data)
+        ));
+
+        // Use ECRecover.recover for address(0) guard
+        require(
+            ECRecover.recover(digest, v, r, s) == spender,
+            "Invalid signature"
+        );
+
+        _authorizationStates[spender][nonce] = true;
+        emit AuthorizationUsed(spender, nonce);
+
+        // Include fee in allowance spend
+        _spendAllowance(from, spender, rawAmount + rawFee);
+        super._transfer(from, to, rawAmount);
+        super._transfer(from, _msgSender(), rawFee);
+
+        emit MetaTransactionFeeCollected(from, _msgSender(), displayFee, rawFee);
+        emit TransferWithMessageCount(from, to, displayAmount, messageCount);
+
+        _mintArigatoCreation(from, rawAmount, rawBalance, messageCount);
     }
 
     /*
@@ -947,6 +1111,6 @@ contract PCECommunityToken is
     }
 
     function version() public pure returns (string memory) {
-        return "1.0.13";
+        return "1.0.14";
     }
 }

--- a/src/PCECommunityToken.sol
+++ b/src/PCECommunityToken.sol
@@ -100,6 +100,7 @@ contract PCECommunityToken is
     event PCETransfer(address indexed from, address indexed to, uint256 displayAmount, uint256 rawAmount);
     event MintArigatoCreation(address indexed to, uint256 displayAmount, uint256 rawAmount);
     event MetaTransactionFeeCollected(address indexed from, address indexed to, uint256 displayFee, uint256 rawFee);
+    event MetaTransactionFeeSwapped(address indexed from, address indexed relayer, uint256 communityTokenFee, uint256 pceFee);
     event InfinityApproveFlagSet(address indexed owner, address indexed spender, bool flag);
 
     function initialize(string memory name, string memory symbol, uint256 _initialFactor) public initializer {
@@ -513,6 +514,15 @@ contract PCECommunityToken is
         return Math.mulDiv(pceTokenFee, rate, 2**96);
     }
 
+    function _collectFeeAsPCE(address from, address relayer, uint256 displayFee) internal returns (uint256) {
+        uint256 rawFee = displayBalanceToRawBalance(displayFee);
+        _burn(from, rawFee);
+        PCEToken pceToken = PCEToken(pceAddress);
+        uint256 pceAmount = pceToken.swapFeeFromLocalToken(address(this), relayer, displayFee);
+        emit MetaTransactionFeeSwapped(from, relayer, displayFee, pceAmount);
+        return pceAmount;
+    }
+
     function transferWithAuthorization(
         address from, address to, uint256 displayAmount, uint256 validAfter, uint256 validBefore, bytes32 nonce, uint8 v, bytes32 r, bytes32 s
     )
@@ -523,16 +533,13 @@ contract PCECommunityToken is
         uint256 rawBalance = super.balanceOf(from);
         uint256 rawAmount = displayBalanceToRawBalance(displayAmount);
         uint256 displayFee = getMetaTransactionFee();
-        uint256 rawFee = displayBalanceToRawBalance(displayFee);
 
         // Prevent zero-amount transfer that only charges fee
         require(rawAmount > 0, "Amount must be greater than zero");
 
         _transferWithAuthorization(from, to, displayAmount, validAfter, validBefore, nonce, v, r, s, rawAmount);
 
-        super._transfer(from, _msgSender(), rawFee);
-
-        emit MetaTransactionFeeCollected(from, _msgSender(), displayFee, rawFee);
+        _collectFeeAsPCE(from, _msgSender(), displayFee);
 
         _mintArigatoCreation(from, rawAmount, rawBalance, 1);
     }
@@ -596,9 +603,8 @@ contract PCECommunityToken is
         // Include fee in allowance spend
         _spendAllowance(from, spender, rawAmount + rawFee);
         super._transfer(from, to, rawAmount);
-        super._transfer(from, _msgSender(), rawFee);
+        _collectFeeAsPCE(from, _msgSender(), displayFee);
 
-        emit MetaTransactionFeeCollected(from, _msgSender(), displayFee, rawFee);
         _mintArigatoCreation(from, rawAmount, rawBalance, 1);
     }
 
@@ -725,8 +731,7 @@ contract PCECommunityToken is
         emit InfinityApproveFlagSet(owner, spender, flag);
 
         // Collect meta transaction fee from owner
-        super._transfer(owner, _msgSender(), rawFee);
-        emit MetaTransactionFeeCollected(owner, _msgSender(), displayFee, rawFee);
+        _collectFeeAsPCE(owner, _msgSender(), displayFee);
     }
 
     // Voucher functions
@@ -835,9 +840,8 @@ contract PCECommunityToken is
         // Transfer amount after fee to claimer
         super._transfer(address(this), claimer, amountAfterFee);
 
-        // Collect meta transaction fee from claimed amount
-        super._transfer(address(this), _msgSender(), rawFee);
-        emit MetaTransactionFeeCollected(claimer, _msgSender(), displayFee, rawFee);
+        // Collect meta transaction fee from claimed amount (swap to PCE for relayer)
+        _collectFeeAsPCE(address(this), _msgSender(), displayFee);
     }
 
     function getVoucherIssuanceInfo(string memory issuanceId)
@@ -946,6 +950,6 @@ contract PCECommunityToken is
     }
 
     function version() public pure returns (string memory) {
-        return "1.0.12";
+        return "1.0.13";
     }
 }

--- a/src/PCEToken.sol
+++ b/src/PCEToken.sol
@@ -321,6 +321,11 @@ contract PCEToken is
         require(msg.sender == fromToken, "Caller must be the community token");
         require(localTokens[fromToken].isExists, "Token not registered");
 
+        // A zero-fee meta-tx is valid (the relayer simply waives the fee).
+        // Short-circuit so the `pcetokenAmount > 0` check below doesn't brick
+        // callers when `communityTokenDisplayAmount` is 0.
+        if (communityTokenDisplayAmount == 0) return 0;
+
         updateFactorIfNeeded();
 
         PCECommunityToken target = PCECommunityToken(fromToken);

--- a/src/PCEToken.sol
+++ b/src/PCEToken.sol
@@ -46,6 +46,9 @@ contract PCEToken is
     event TokensSwappedFromLocalToken(
         address indexed to, address indexed fromToken, uint256 targetTokenAmount, uint256 pceTokenAmount
     );
+    event FeeSwappedFromLocalToken(
+        address indexed fromToken, address indexed relayer, uint256 communityTokenAmount, uint256 pceAmount
+    );
 
     uint256 public constant INITIAL_FACTOR = 10 ** 18;
     uint256 private constant Q96 = 2 ** 96;
@@ -307,6 +310,40 @@ contract PCEToken is
         emit TokensSwappedFromLocalToken(_msgSender(), fromToken, amountToSwap, pcetokenAmount);
     }
 
+    function swapFeeFromLocalToken(
+        address fromToken,
+        address relayer,
+        uint256 communityTokenDisplayAmount
+    )
+        external
+        returns (uint256)
+    {
+        require(msg.sender == fromToken, "Caller must be the community token");
+        require(localTokens[fromToken].isExists, "Token not registered");
+
+        updateFactorIfNeeded();
+
+        PCECommunityToken target = PCECommunityToken(fromToken);
+
+        uint256 pcetokenAmount = Math.mulDiv(
+            Math.mulDiv(communityTokenDisplayAmount, INITIAL_FACTOR, localTokens[fromToken].exchangeRate),
+            lastModifiedFactor,
+            target.getCurrentFactor()
+        );
+        require(pcetokenAmount > 0, "Fee swap amount too small");
+        require(
+            localTokens[fromToken].depositedPCEToken >= pcetokenAmount,
+            "Insufficient deposited PCE token reserve"
+        );
+
+        _transfer(address(this), relayer, pcetokenAmount);
+        localTokens[fromToken].depositedPCEToken -= pcetokenAmount;
+
+        emit FeeSwappedFromLocalToken(fromToken, relayer, communityTokenDisplayAmount, pcetokenAmount);
+
+        return pcetokenAmount;
+    }
+
     function getNativeTokenToPceTokenRate() public view returns (uint256) {
         return nativeTokenToPceTokenRate;
     }
@@ -387,6 +424,6 @@ contract PCEToken is
     function _authorizeUpgrade(address newImplementation) internal virtual override onlyOwner { }
 
     function version() public pure returns (string memory) {
-        return "1.0.12";
+        return "1.0.13";
     }
 }

--- a/src/lib/ArigatoCreation.sol
+++ b/src/lib/ArigatoCreation.sol
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.30;
+
+import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
+
+/// @title ArigatoCreation
+/// @notice Library encapsulating the Arigato Creation mint calculation to
+///         reduce PCECommunityToken bytecode.
+library ArigatoCreation {
+    uint16 internal constant BP_BASE = 10_000;
+    uint16 internal constant MAX_CHARACTER_LENGTH = 10;
+
+    struct AccountInfo {
+        uint256 midnightBalance;
+        uint256 firstTransactionTime;
+        uint256 lastModifiedMidnightBalanceTime;
+        uint256 mintArigatoCreationToday;
+    }
+
+    struct Params {
+        uint256 midnightTotalSupply;
+        uint16 maxIncreaseOfTotalSupplyBp;
+        uint16 maxIncreaseBp;
+        uint16 maxUsageBp;
+        uint16 changeBp;
+        uint256 mintArigatoCreationToday;
+        uint256 mintArigatoCreationTodayForGuest;
+        uint256 rawAmount;
+        uint256 rawBalance;
+        uint256 messageCharacters;
+    }
+
+    /// @notice Compute the Arigato Creation mint amount and updated counters.
+    ///         Returns `mintAmount = 0` when the caller should skip minting.
+    function compute(
+        AccountInfo memory accountInfo,
+        Params memory p
+    )
+        public
+        pure
+        returns (
+            uint256 mintAmount,
+            bool isGuest
+        )
+    {
+        uint256 maxArigatoCreationMintToday = Math.mulDiv(p.midnightTotalSupply, p.maxIncreaseOfTotalSupplyBp, BP_BASE);
+        if (maxArigatoCreationMintToday == 0 || maxArigatoCreationMintToday <= p.mintArigatoCreationToday) {
+            return (0, false);
+        }
+        uint256 remainingToday = maxArigatoCreationMintToday - p.mintArigatoCreationToday;
+        uint256 remainingTodayForGuest;
+
+        isGuest = accountInfo.firstTransactionTime == accountInfo.lastModifiedMidnightBalanceTime;
+        if (isGuest) {
+            uint256 maxForGuest = Math.mulDiv(maxArigatoCreationMintToday, 1, 10);
+            if (maxForGuest == 0 || maxForGuest <= p.mintArigatoCreationTodayForGuest) {
+                return (0, isGuest);
+            }
+            remainingTodayForGuest = maxForGuest - p.mintArigatoCreationTodayForGuest;
+        }
+
+        uint256 usageBp = Math.mulDiv(p.rawAmount, BP_BASE, p.rawBalance);
+        uint256 absUsageBp = usageBp > p.maxUsageBp ? usageBp - p.maxUsageBp : uint256(p.maxUsageBp) - usageBp;
+        uint256 changeMulBp = Math.mulDiv(uint256(p.changeBp), absUsageBp, BP_BASE);
+        if (changeMulBp >= p.maxIncreaseBp) {
+            return (0, isGuest);
+        }
+        uint256 messageLength = p.messageCharacters > 0 ? p.messageCharacters : 1;
+        uint256 messageBp =
+            messageLength > MAX_CHARACTER_LENGTH ? BP_BASE : Math.mulDiv(messageLength, BP_BASE, MAX_CHARACTER_LENGTH);
+        uint256 increaseBp = uint256(p.maxIncreaseBp) - Math.mulDiv(changeMulBp, messageBp, BP_BASE);
+        mintAmount = Math.mulDiv(p.rawAmount, increaseBp, BP_BASE);
+        if (mintAmount > remainingToday) {
+            mintAmount = remainingToday;
+        }
+
+        uint256 actualMinted =
+            accountInfo.mintArigatoCreationToday > 0 ? accountInfo.mintArigatoCreationToday - 1 : 0;
+
+        if (!isGuest) {
+            uint256 maxForSender = Math.mulDiv(maxArigatoCreationMintToday, accountInfo.midnightBalance, p.midnightTotalSupply);
+            if (maxForSender == 0) return (0, isGuest);
+            uint256 remainingSender = maxForSender > actualMinted ? maxForSender - actualMinted : 0;
+            if (remainingSender == 0) return (0, isGuest);
+            if (mintAmount > remainingSender) mintAmount = remainingSender;
+        } else {
+            if (mintAmount > remainingTodayForGuest) mintAmount = remainingTodayForGuest;
+            uint256 maxGuestSender = Math.mulDiv(maxArigatoCreationMintToday, 1, 100);
+            if (maxGuestSender == 0) return (0, isGuest);
+            uint256 remainingGuestSender = maxGuestSender > actualMinted ? maxGuestSender - actualMinted : 0;
+            if (remainingGuestSender == 0) return (0, isGuest);
+            if (mintAmount > remainingGuestSender) mintAmount = remainingGuestSender;
+        }
+    }
+}

--- a/src/lib/EIP3009.sol
+++ b/src/lib/EIP3009.sol
@@ -28,8 +28,6 @@ abstract contract EIP3009 is ERC20Upgradeable, EIP712Domain {
 
     event AuthorizationUsed(address indexed authorizer, bytes32 indexed nonce);
 
-    string internal constant _INVALID_SIGNATURE_ERROR = "EIP3009: invalid signature";
-
     function authorizationState(address authorizer, bytes32 nonce) external view returns (bool) {
         return _authorizationStates[authorizer][nonce];
     }

--- a/src/lib/TokenValueOps.sol
+++ b/src/lib/TokenValueOps.sol
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.30;
+
+import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
+import { ExchangeAllowMethod } from "./Enum.sol";
+import { PCEToken } from "../PCEToken.sol";
+import { Utils } from "./Utils.sol";
+
+library TokenValueOps {
+    event TreasuryWalletSet(address indexed wallet);
+    event TokenValueIncreased(uint256 pceAmount, uint256 oldExchangeRate, uint256 newExchangeRate);
+    event TokenSplit(
+        uint256 mintAmount,
+        uint256 oldExchangeRate,
+        uint256 newExchangeRate,
+        uint256 oldRebaseFactor,
+        uint256 newRebaseFactor
+    );
+    event RateManagerRoleGranted(address indexed account);
+    event RateManagerRoleRevoked(address indexed account);
+
+    function computeSwapAmount(
+        address pceAddress,
+        address fromCommunityToken,
+        address toCommunityToken,
+        uint256 amountToSwap,
+        uint256 fromCurrentFactor,
+        uint256 toCurrentFactor
+    )
+        public
+        view
+        returns (uint256 targetTokenAmount)
+    {
+        PCEToken pceToken = PCEToken(pceAddress);
+        Utils.LocalToken memory fromToken = pceToken.getLocalToken(fromCommunityToken);
+        require(fromToken.isExists, "From token not found");
+        Utils.LocalToken memory toToken = pceToken.getLocalToken(toCommunityToken);
+        require(toToken.isExists, "Target token not found");
+
+        uint256 pceCurrent = pceToken.getCurrentFactor();
+        targetTokenAmount = Math.mulDiv(
+            Math.mulDiv(
+                Math.mulDiv(amountToSwap, 10 ** 18, fromToken.exchangeRate),
+                pceCurrent,
+                fromCurrentFactor
+            ),
+            Math.mulDiv(toToken.exchangeRate, toCurrentFactor, 10 ** 18),
+            pceCurrent
+        );
+        require(targetTokenAmount > 0, "Invalid amount to swap");
+    }
+
+    function isAllowExchange(
+        bool isIncome,
+        address tokenAddress,
+        ExchangeAllowMethod incomeAllow,
+        ExchangeAllowMethod outgoAllow,
+        address[] memory incomeTargets,
+        address[] memory outgoTargets
+    )
+        public
+        pure
+        returns (bool)
+    {
+        ExchangeAllowMethod allowMethod = isIncome ? incomeAllow : outgoAllow;
+        address[] memory targetTokens = isIncome ? incomeTargets : outgoTargets;
+        if (allowMethod == ExchangeAllowMethod.None) return false;
+        if (allowMethod == ExchangeAllowMethod.All) return true;
+        if (allowMethod == ExchangeAllowMethod.Include) {
+            for (uint256 i = 0; i < targetTokens.length;) {
+                if (targetTokens[i] == tokenAddress) return true;
+                unchecked { i++; }
+            }
+            return false;
+        } else if (allowMethod == ExchangeAllowMethod.Exclude) {
+            for (uint256 i = 0; i < targetTokens.length;) {
+                if (targetTokens[i] == tokenAddress) return false;
+                unchecked { i++; }
+            }
+            return true;
+        }
+        revert("Invalid exchangeAllowMethod");
+    }
+
+    function initializeTreasury(
+        address currentTreasury,
+        address wallet,
+        address sender,
+        mapping(bytes32 => mapping(address => bool)) storage roles,
+        bytes32 role
+    )
+        public
+        returns (address newTreasury, uint256 newRebaseFactor)
+    {
+        require(currentTreasury == address(0), "Already initialized");
+        require(wallet != address(0), "Invalid wallet address");
+        roles[role][sender] = true;
+        emit TreasuryWalletSet(wallet);
+        emit RateManagerRoleGranted(sender);
+        return (wallet, 10 ** 18);
+    }
+
+    function setTreasuryWallet(address wallet) public returns (address) {
+        require(wallet != address(0), "Invalid wallet address");
+        emit TreasuryWalletSet(wallet);
+        return wallet;
+    }
+
+    function increaseTokenValue(
+        uint256 pceAmount,
+        address pceAddress,
+        address self,
+        address treasuryWallet
+    )
+        public
+    {
+        require(pceAmount > 0, "Amount must be > 0");
+        PCEToken pceToken = PCEToken(pceAddress);
+        uint256 oldExchangeRate = pceToken.getExchangeRate(self);
+        pceToken.addReserve(self, pceAmount, treasuryWallet);
+        uint256 newExchangeRate = pceToken.getExchangeRate(self);
+        emit TokenValueIncreased(pceAmount, oldExchangeRate, newExchangeRate);
+    }
+
+    function splitToken(
+        uint256 mintAmount,
+        uint256 currentTotalDisplay,
+        uint256 oldRebaseFactor,
+        address pceAddress,
+        address self
+    )
+        public
+        returns (uint256 newRebaseFactor)
+    {
+        require(mintAmount > 0, "Amount must be > 0");
+        require(currentTotalDisplay > 0, "No supply to split");
+
+        PCEToken pceToken = PCEToken(pceAddress);
+        uint256 oldExchangeRate = pceToken.getExchangeRate(self);
+
+        newRebaseFactor = Math.mulDiv(oldRebaseFactor, currentTotalDisplay + mintAmount, currentTotalDisplay);
+
+        uint256 newRate = Math.mulDiv(oldExchangeRate, newRebaseFactor, oldRebaseFactor);
+        pceToken.adjustExchangeRate(self, newRate);
+
+        uint256 newExchangeRate = pceToken.getExchangeRate(self);
+        emit TokenSplit(mintAmount, oldExchangeRate, newExchangeRate, oldRebaseFactor, newRebaseFactor);
+    }
+
+    function grantRateManagerRole(
+        address account,
+        mapping(bytes32 => mapping(address => bool)) storage roles,
+        bytes32 role
+    )
+        public
+    {
+        require(account != address(0), "Invalid account address");
+        roles[role][account] = true;
+        emit RateManagerRoleGranted(account);
+    }
+
+    function revokeRateManagerRole(
+        address account,
+        mapping(bytes32 => mapping(address => bool)) storage roles,
+        bytes32 role
+    )
+        public
+    {
+        require(account != address(0), "Invalid account address");
+        roles[role][account] = false;
+        emit RateManagerRoleRevoked(account);
+    }
+}

--- a/src/lib/VoucherSystem.sol
+++ b/src/lib/VoucherSystem.sol
@@ -2,6 +2,18 @@
 pragma solidity 0.8.30;
 
 import { MerkleProof } from "@openzeppelin/contracts/utils/cryptography/MerkleProof.sol";
+import { ECRecover } from "./ECRecover.sol";
+
+/// @dev Self-call helpers used by public wrapper functions below. The host
+///      contract MUST restrict these to `msg.sender == address(this)`.
+interface IVoucherHost {
+    function __libTransfer(address from, address to, uint256 rawAmount) external;
+    function __libCollectFeeAsPCE(address from, address relayer, uint256 displayFee) external;
+    function balanceOf(address account) external view returns (uint256);
+    function displayBalanceToRawBalance(uint256 displayBalance) external view returns (uint256);
+    function getMetaTransactionFee() external view returns (uint256);
+    function DOMAIN_SEPARATOR() external view returns (bytes32);
+}
 
 library VoucherSystem {
     // Error codes for canClaim function
@@ -60,6 +72,15 @@ library VoucherSystem {
     event VoucherFundsWithdrawn(string indexed issuanceId, uint256 rawAmount);
     event VoucherIssuanceTerminated(string indexed issuanceId);
 
+    /// @dev Claim-with-authorization typehash. MUST match the host's typehash.
+    bytes32 private constant CLAIM_WITH_AUTHORIZATION_TYPEHASH =
+        0x0b6aae1d90e3a85a25061f4c51e754a9cce2a86cf2f51fb09be1001de8fb7c0a;
+
+    /// @dev Matches the EIP3009 event signature so observers cannot distinguish
+    ///      whether the host or this library emitted it.
+    event AuthorizationUsed(address indexed authorizer, bytes32 indexed nonce);
+
+
     function registerIssuance(
         VoucherStorage storage self,
         string memory issuanceId,
@@ -74,7 +95,7 @@ library VoucherSystem {
         address owner,
         string memory ipfsCid
     )
-        internal
+        public
     {
         // endTime == 0 means unlimited duration, otherwise endTime must be after startTime
         require(endTime == 0 || endTime > startTime, "End time should be after start time");
@@ -119,7 +140,7 @@ library VoucherSystem {
         address claimer,
         uint256 claimRawAmount
     )
-        internal
+        public
         returns (uint256)
     {
         VoucherIssuance memory issuance = self.issuances[issuanceId];
@@ -133,24 +154,12 @@ library VoucherSystem {
         require(issuance.endTime == 0 || block.timestamp < issuance.endTime, "Issuance already ended");
 
         // Check claim count limit per user (0 means unlimited)
-        require(
-            issuance.countLimitPerUser == 0 || self.claimCountPerUser[issuanceId][claimer] < issuance.countLimitPerUser,
-            "Claim count reached limitation"
-        );
-        require(
-            self.remainingRawAmount[issuanceId] >= claimRawAmount,
-            "No more claimable amount"
-        );
+        require(issuance.countLimitPerUser == 0 || self.claimCountPerUser[issuanceId][claimer] < issuance.countLimitPerUser, "Claim count reached limitation");
+        require(self.remainingRawAmount[issuanceId] >= claimRawAmount, "No more claimable amount");
         if (issuance.totalAmountLimit > 0) {
-            require(
-                self.claimedDisplayAmount[issuanceId] + issuance.amountPerClaim <= issuance.totalAmountLimit,
-                "Total amount limit exceeded"
-            );
+            require(self.claimedDisplayAmount[issuanceId] + issuance.amountPerClaim <= issuance.totalAmountLimit, "Total amount limit exceeded");
         }
-        require(
-            MerkleProof.verify(proof, issuance.merkleRoot, keccak256(abi.encodePacked(code))),
-            "Invalid claim proof"
-        );
+        require(MerkleProof.verify(proof, issuance.merkleRoot, keccak256(abi.encodePacked(code))), "Invalid claim proof");
         require(!self.isCodeUsed[issuanceId][code], "Code already used");
 
         self.claimCountPerUser[issuanceId][claimer]++;
@@ -171,7 +180,7 @@ library VoucherSystem {
         uint256 rawAmount,
         address sender
     )
-        internal
+        public
     {
         VoucherIssuance storage issuance = self.issuances[issuanceId];
         require(bytes(issuance.issuanceId).length != 0, "Issuance not found");
@@ -189,7 +198,7 @@ library VoucherSystem {
         uint256 rawAmount,
         address sender
     )
-        internal
+        public
         returns (uint256)
     {
         VoucherIssuance storage issuance = self.issuances[issuanceId];
@@ -210,7 +219,7 @@ library VoucherSystem {
         string memory issuanceId,
         address sender
     )
-        internal
+        public
         returns (uint256)
     {
         VoucherIssuance storage issuance = self.issuances[issuanceId];
@@ -337,5 +346,160 @@ library VoucherSystem {
         }
 
         return (true, ERROR_NONE);
+    }
+
+    // ==================================================================
+    //  High-level wrappers (called from PCECommunityToken, handle the
+    //  display↔raw conversion and token movements via self-call hooks).
+    //  Moving them out of PCECommunityToken keeps its bytecode below the
+    //  EVM contract size limit.
+    // ==================================================================
+
+    function registerIssuanceWithLock(
+        VoucherStorage storage self,
+        string memory issuanceId,
+        string memory name,
+        uint256 amountPerClaim,
+        uint256 countLimitPerUser,
+        uint256 totalAmountLimit,
+        uint256 initialFundsDisplayAmount,
+        uint256 startTime,
+        uint256 endTime,
+        bytes32 merkleRoot,
+        string memory ipfsCid
+    )
+        public
+    {
+        IVoucherHost host = IVoucherHost(address(this));
+        address sender = msg.sender;
+        require(!(host.balanceOf(sender) < initialFundsDisplayAmount), "Insufficient balance");
+        uint256 initialFundsRawAmount = host.displayBalanceToRawBalance(initialFundsDisplayAmount);
+
+        registerIssuance(
+            self, issuanceId, name, amountPerClaim, countLimitPerUser, totalAmountLimit,
+            initialFundsRawAmount, startTime, endTime, merkleRoot, sender, ipfsCid
+        );
+
+        host.__libTransfer(sender, address(this), initialFundsRawAmount);
+    }
+
+    function claimAndTransfer(
+        VoucherStorage storage self,
+        string memory issuanceId,
+        string memory code,
+        bytes32[] calldata proof
+    )
+        public
+    {
+        IVoucherHost host = IVoucherHost(address(this));
+        VoucherIssuance memory issuance = self.issuances[issuanceId];
+        uint256 rawClaimAmount = host.displayBalanceToRawBalance(issuance.amountPerClaim);
+
+        address claimer = msg.sender;
+        claim(self, issuanceId, code, proof, claimer, rawClaimAmount);
+        host.__libTransfer(address(this), claimer, rawClaimAmount);
+    }
+
+    function claimWithAuthorizationAndTransfer(
+        VoucherStorage storage self,
+        mapping(address => mapping(bytes32 => bool)) storage authStates,
+        address claimer,
+        string memory issuanceId,
+        string memory code,
+        bytes32[] calldata proof,
+        uint256 validAfter,
+        uint256 validBefore,
+        bytes32 nonce,
+        uint8 v,
+        bytes32 r,
+        bytes32 s,
+        address relayer
+    )
+        public
+    {
+        IVoucherHost host = IVoucherHost(address(this));
+
+        require(!(block.timestamp <= validAfter), "Not yet valid");
+        require(!(block.timestamp >= validBefore), "Authorization expired");
+        require(!(authStates[claimer][nonce]), "Authorization used");
+
+        bytes32 digest;
+        {
+            bytes memory data = abi.encode(
+                CLAIM_WITH_AUTHORIZATION_TYPEHASH,
+                claimer, keccak256(bytes(issuanceId)), keccak256(bytes(code)),
+                validAfter, validBefore, nonce
+            );
+            digest = keccak256(abi.encodePacked("\x19\x01", host.DOMAIN_SEPARATOR(), keccak256(data)));
+        }
+        require(!(ECRecover.recover(digest, v, r, s) != claimer), "Invalid signature");
+        authStates[claimer][nonce] = true;
+        emit AuthorizationUsed(claimer, nonce);
+
+        // Surface the `Issuance not found` error consistently with claim() instead
+        // of reverting later via a zero-amount fee check on a non-existent entry.
+        require(bytes(self.issuances[issuanceId].issuanceId).length != 0, "Issuance not found");
+
+        uint256 displayFee = host.getMetaTransactionFee();
+        uint256 rawFee = host.displayBalanceToRawBalance(displayFee);
+        uint256 rawClaimAmount = host.displayBalanceToRawBalance(self.issuances[issuanceId].amountPerClaim);
+        require(!(rawClaimAmount <= rawFee), "Claim amount must be greater than fee");
+
+        claim(self, issuanceId, code, proof, claimer, rawClaimAmount);
+
+        host.__libTransfer(address(this), claimer, rawClaimAmount - rawFee);
+        // When `displayFee` rounds down to `rawFee == 0` (e.g. extreme
+        // rebase factor), we didn't actually withhold anything from the
+        // claimer, so skip the PCE swap to avoid paying the relayer out of
+        // the PCE reserve without a matching CT burn.
+        if (rawFee > 0) {
+            host.__libCollectFeeAsPCE(address(this), relayer, displayFee);
+        }
+    }
+
+    function addFundsWithTransfer(
+        VoucherStorage storage self,
+        string memory issuanceId,
+        uint256 displayAmount
+    )
+        public
+    {
+        IVoucherHost host = IVoucherHost(address(this));
+        address sender = msg.sender;
+        require(!(host.balanceOf(sender) < displayAmount), "Insufficient balance");
+        uint256 rawAmount = host.displayBalanceToRawBalance(displayAmount);
+
+        addFunds(self, issuanceId, rawAmount, sender);
+        host.__libTransfer(sender, address(this), rawAmount);
+    }
+
+    function withdrawFundsWithTransfer(
+        VoucherStorage storage self,
+        string memory issuanceId,
+        uint256 displayAmount
+    )
+        public
+    {
+        IVoucherHost host = IVoucherHost(address(this));
+        uint256 rawAmount = host.displayBalanceToRawBalance(displayAmount);
+        address sender = msg.sender;
+
+        uint256 withdrawnRawAmount = withdrawFunds(self, issuanceId, rawAmount, sender);
+        host.__libTransfer(address(this), sender, withdrawnRawAmount);
+    }
+
+    function terminateWithRefund(
+        VoucherStorage storage self,
+        string memory issuanceId
+    )
+        public
+    {
+        IVoucherHost host = IVoucherHost(address(this));
+        address sender = msg.sender;
+
+        uint256 remainingRawAmount = terminateIssuance(self, issuanceId, sender);
+        if (remainingRawAmount > 0) {
+            host.__libTransfer(address(this), sender, remainingRawAmount);
+        }
     }
 }

--- a/test/PCE.t.sol
+++ b/test/PCE.t.sol
@@ -350,6 +350,72 @@ contract PCETest is Test {
 
     function testVersion() public view {
         assertEq(pceToken.version(), "1.0.12");
-        assertEq(token.version(), "1.0.13");
+        assertEq(token.version(), "1.0.14");
+    }
+
+    function testTransferWithMessageCount() public {
+        vm.startPrank(owner);
+        // Transfer 100 tokens to user1 first
+        token.transfer(user1, 100 ether);
+        vm.stopPrank();
+
+        // Advance 1 day so user1 is no longer a "guest" (firstTransactionTime != lastModifiedMidnightBalanceTime)
+        vm.warp(block.timestamp + 1 days + 1);
+
+        vm.startPrank(user1);
+        uint256 balanceBefore = token.balanceOf(user1);
+
+        // Transfer with messageCount=5
+        token.transferWithMessageCount(user2, 10 ether, 5);
+
+        uint256 balanceAfterMsg5 = token.balanceOf(user1);
+        // user1 should have less than before (sent 10) but may have arigato mint
+        uint256 user2Balance = token.balanceOf(user2);
+        assertGt(user2Balance, 0, "user2 should have received tokens");
+        vm.stopPrank();
+    }
+
+    function testTransferWithMessageCountEmitsEvent() public {
+        vm.startPrank(owner);
+        token.transfer(user1, 100 ether);
+        vm.stopPrank();
+
+        vm.startPrank(user1);
+        vm.expectEmit(true, true, false, true);
+        emit PCECommunityToken.TransferWithMessageCount(user1, user2, 10 ether, 7);
+        token.transferWithMessageCount(user2, 10 ether, 7);
+        vm.stopPrank();
+    }
+
+    function testTransferFromWithMessageCount() public {
+        vm.startPrank(owner);
+        token.transfer(user1, 100 ether);
+        vm.stopPrank();
+
+        // user1 approves owner to spend
+        vm.startPrank(user1);
+        token.approve(owner, 50 ether);
+        vm.stopPrank();
+
+        vm.startPrank(owner);
+        token.transferFromWithMessageCount(user1, user2, 10 ether, 3);
+        uint256 user2Balance = token.balanceOf(user2);
+        assertGt(user2Balance, 0, "user2 should have received tokens");
+        vm.stopPrank();
+    }
+
+    function testTransferWithMessageCountZeroTreatedAsOne() public {
+        vm.startPrank(owner);
+        token.transfer(user1, 100 ether);
+        vm.stopPrank();
+
+        vm.warp(block.timestamp + 1 days + 1);
+
+        vm.startPrank(user1);
+        // messageCount=0 should behave like messageCount=1 (internal _mintArigatoCreation clamps to 1)
+        token.transferWithMessageCount(user2, 10 ether, 0);
+        uint256 user2Balance = token.balanceOf(user2);
+        assertGt(user2Balance, 0, "user2 should have received tokens");
+        vm.stopPrank();
     }
 }

--- a/test/PCE.t.sol
+++ b/test/PCE.t.sol
@@ -806,6 +806,255 @@ contract PCETest is Test {
         assertTrue(token.balanceOf(user2) > user2CTBefore, "Recipient should receive community tokens");
     }
 
+    // --- PIP-13 fee swap across remaining *WithAuthorization* paths ---
+    // These all use `this.DOMAIN_SEPARATOR()` (ERC20Permit domain), not the
+    // hardcoded "PeaceBaseCoin" domain used by _transferWithAuthorization.
+
+    function _setupAuthSigner(uint256 pk, uint256 initialCT) internal returns (address signer) {
+        signer = vm.addr(pk);
+        vm.startPrank(owner);
+        pceToken.swapToLocalToken(address(token), 500 ether);
+        vm.warp(block.timestamp + 1 days);
+        token.transfer(signer, initialCT);
+        vm.warp(block.timestamp + 1 days);
+        vm.stopPrank();
+    }
+
+    function _signDigestBytes(uint256 pk, bytes memory data) internal view returns (uint8 v, bytes32 r, bytes32 s) {
+        bytes32 digest = keccak256(abi.encodePacked("\x19\x01", token.DOMAIN_SEPARATOR(), keccak256(data)));
+        (v, r, s) = vm.sign(pk, digest);
+    }
+
+    function testTransferFromWithAuthorizationFeeSwap() public {
+        // In transferFromWithAuthorization the `spender` is the authorizer
+        // (who signs) and must hold allowance over `from`. We set
+        // spender == from == signer so the signer effectively authorises
+        // themselves; the relayer just submits the transaction.
+        uint256 pk = 0xBE11E;
+        address signer = _setupAuthSigner(pk, 50 ether);
+        address relayer = address(0x9A);
+
+        vm.prank(signer);
+        token.approve(signer, 20 ether);
+
+        uint256 nonce = uint256(bytes32(keccak256("tf-auth-fee")));
+        uint256 amt = 5 ether;
+        bytes memory data = abi.encode(
+            token.TRANSFER_FROM_WITH_AUTHORIZATION_TYPEHASH(),
+            signer, signer, user2, amt, uint256(0), type(uint256).max, bytes32(nonce)
+        );
+        (uint8 v, bytes32 r, bytes32 s) = _signDigestBytes(pk, data);
+
+        uint256 relayerPCEBefore = pceToken.balanceOf(relayer);
+        uint256 relayerCTBefore = token.balanceOf(relayer);
+        uint256 user2Before = token.balanceOf(user2);
+
+        vm.prank(relayer);
+        token.transferFromWithAuthorization(
+            signer, signer, user2, amt, 0, type(uint256).max, bytes32(nonce), v, r, s
+        );
+
+        assertGt(pceToken.balanceOf(relayer), relayerPCEBefore, "relayer should receive PCE fee");
+        assertEq(token.balanceOf(relayer), relayerCTBefore, "relayer should NOT receive CT");
+        assertGt(token.balanceOf(user2), user2Before, "recipient should receive tokens");
+    }
+
+    function testTransferWithAuthorizationWithMessageCount() public {
+        uint256 pk = 0xBEE;
+        address signer = _setupAuthSigner(pk, 50 ether);
+        address relayer = address(0x9B);
+
+        uint256 nonce = uint256(bytes32(keccak256("tw-mc-auth")));
+        uint256 amt = 5 ether;
+        uint256 messageCount = 7;
+        bytes memory data = abi.encode(
+            token.TRANSFER_WITH_AUTHORIZATION_WITH_MESSAGE_COUNT_TYPEHASH(),
+            signer, user2, amt, uint256(0), type(uint256).max, bytes32(nonce), messageCount
+        );
+        (uint8 v, bytes32 r, bytes32 s) = _signDigestBytes(pk, data);
+
+        uint256 relayerPCEBefore = pceToken.balanceOf(relayer);
+        uint256 user2Before = token.balanceOf(user2);
+
+        vm.expectEmit(true, true, false, true);
+        emit PCECommunityToken.TransferWithMessageCount(signer, user2, amt, messageCount);
+
+        vm.prank(relayer);
+        token.transferWithAuthorizationWithMessageCount(
+            signer, user2, amt, 0, type(uint256).max, bytes32(nonce), v, r, s, messageCount
+        );
+
+        assertGt(pceToken.balanceOf(relayer), relayerPCEBefore, "relayer should receive PCE fee");
+        assertGt(token.balanceOf(user2), user2Before, "recipient should receive tokens");
+    }
+
+    function testTransferWithAuthorizationWithMessageCountRejectsReplay() public {
+        uint256 pk = 0xBEE2;
+        address signer = _setupAuthSigner(pk, 50 ether);
+        address relayer = address(0x9C);
+
+        uint256 nonce = uint256(bytes32(keccak256("tw-mc-replay")));
+        bytes memory data = abi.encode(
+            token.TRANSFER_WITH_AUTHORIZATION_WITH_MESSAGE_COUNT_TYPEHASH(),
+            signer, user2, uint256(1 ether), uint256(0), type(uint256).max, bytes32(nonce), uint256(1)
+        );
+        (uint8 v, bytes32 r, bytes32 s) = _signDigestBytes(pk, data);
+
+        vm.prank(relayer);
+        token.transferWithAuthorizationWithMessageCount(
+            signer, user2, 1 ether, 0, type(uint256).max, bytes32(nonce), v, r, s, 1
+        );
+
+        vm.prank(relayer);
+        vm.expectRevert("Authorization used");
+        token.transferWithAuthorizationWithMessageCount(
+            signer, user2, 1 ether, 0, type(uint256).max, bytes32(nonce), v, r, s, 1
+        );
+    }
+
+    function testTransferFromWithAuthorizationWithMessageCount() public {
+        // Same authorizer-self pattern as testTransferFromWithAuthorizationFeeSwap.
+        uint256 pk = 0xBEE3;
+        address signer = _setupAuthSigner(pk, 50 ether);
+        address relayer = address(0x9D);
+
+        vm.prank(signer);
+        token.approve(signer, 20 ether);
+
+        uint256 nonce = uint256(bytes32(keccak256("tfw-mc")));
+        uint256 amt = 3 ether;
+        uint256 messageCount = 5;
+        bytes memory data = abi.encode(
+            token.TRANSFER_FROM_WITH_AUTHORIZATION_WITH_MESSAGE_COUNT_TYPEHASH(),
+            signer, signer, user2, amt, uint256(0), type(uint256).max, bytes32(nonce), messageCount
+        );
+        (uint8 v, bytes32 r, bytes32 s) = _signDigestBytes(pk, data);
+
+        uint256 relayerPCEBefore = pceToken.balanceOf(relayer);
+        uint256 user2Before = token.balanceOf(user2);
+
+        vm.prank(relayer);
+        token.transferFromWithAuthorizationWithMessageCount(
+            signer, signer, user2, amt, 0, type(uint256).max, bytes32(nonce), v, r, s, messageCount
+        );
+
+        assertGt(pceToken.balanceOf(relayer), relayerPCEBefore, "relayer should receive PCE fee");
+        assertGt(token.balanceOf(user2), user2Before, "recipient should receive tokens");
+    }
+
+    function testSetInfinityApproveFlagWithAuthorizationFeeSwap() public {
+        uint256 pk = 0xBEE4;
+        address signer = _setupAuthSigner(pk, 50 ether);
+        address relayer = address(0x9E);
+        address spender = address(0xAA);
+
+        uint256 nonce = uint256(bytes32(keccak256("set-inf-auth")));
+        bytes memory data = abi.encode(
+            token.SET_INFINITY_APPROVE_FLAG_WITH_AUTHORIZATION_TYPEHASH(),
+            signer, spender, true, uint256(0), type(uint256).max, bytes32(nonce)
+        );
+        (uint8 v, bytes32 r, bytes32 s) = _signDigestBytes(pk, data);
+
+        uint256 relayerPCEBefore = pceToken.balanceOf(relayer);
+        assertFalse(token.getInfinityApproveFlag(signer, spender), "flag should start false");
+
+        vm.prank(relayer);
+        token.setInfinityApproveFlagWithAuthorization(
+            signer, spender, true, 0, type(uint256).max, bytes32(nonce), v, r, s
+        );
+
+        assertTrue(token.getInfinityApproveFlag(signer, spender), "flag should be set true");
+        assertGt(pceToken.balanceOf(relayer), relayerPCEBefore, "relayer should receive PCE fee");
+    }
+
+    function testClaimVoucherWithAuthorizationRejectsReplay() public {
+        // VoucherSystem.claimWithAuthorizationAndTransfer has its own nonce
+        // check (not sharing _useAuthorization); verify it still blocks replay.
+        uint256 pk = 0xBEE6;
+        address signer = _setupAuthSigner(pk, 0);
+        address relayer = address(0xA1);
+
+        bytes32 leaf = keccak256(abi.encodePacked("REPLAY-CODE"));
+        uint256 endTime = block.timestamp + 365 days;
+        vm.startPrank(owner);
+        // Configure countLimitPerUser=2 so the first claim does not exhaust the
+        // per-user limit, and we can prove the second attempt is rejected by nonce.
+        token.registerVoucherIssuance(
+            "VR001", "replay-voucher", 10 ether, 2, 20 ether, 20 ether,
+            0, endTime, leaf, ""
+        );
+        vm.stopPrank();
+
+        uint256 nonce = uint256(bytes32(keccak256("claim-replay")));
+        bytes32[] memory proof = new bytes32[](0);
+        bytes memory data = abi.encode(
+            token.CLAIM_WITH_AUTHORIZATION_TYPEHASH(),
+            signer,
+            keccak256(bytes("VR001")),
+            keccak256(bytes("REPLAY-CODE")),
+            uint256(0),
+            type(uint256).max,
+            bytes32(nonce)
+        );
+        (uint8 v, bytes32 r, bytes32 s) = _signDigestBytes(pk, data);
+
+        vm.prank(relayer);
+        token.claimVoucherWithAuthorization(
+            signer, "VR001", "REPLAY-CODE", proof, 0, type(uint256).max, bytes32(nonce), v, r, s
+        );
+
+        vm.prank(relayer);
+        vm.expectRevert("Authorization used");
+        token.claimVoucherWithAuthorization(
+            signer, "VR001", "REPLAY-CODE", proof, 0, type(uint256).max, bytes32(nonce), v, r, s
+        );
+    }
+
+    function testClaimVoucherWithAuthorizationFeeSwap() public {
+        uint256 pk = 0xBEE5;
+        address signer = _setupAuthSigner(pk, 0); // claimer needs no prior balance
+        address relayer = address(0x9F);
+
+        // Register a voucher funded by `owner`.
+        // Simple 1-leaf merkle tree: root = keccak256(code)
+        bytes32 leaf = keccak256(abi.encodePacked("CLAIMCODE-001"));
+
+        // Use a far-future endTime so factor-decay warps do not invalidate it.
+        uint256 endTime = block.timestamp + 365 days;
+        vm.startPrank(owner);
+        token.registerVoucherIssuance(
+            "VA001", "auth-voucher", 10 ether, 1, 10 ether, 10 ether,
+            0, endTime, leaf, ""
+        );
+        vm.stopPrank();
+
+        uint256 nonce = uint256(bytes32(keccak256("claim-auth")));
+        bytes32[] memory proof = new bytes32[](0);
+        bytes memory data = abi.encode(
+            token.CLAIM_WITH_AUTHORIZATION_TYPEHASH(),
+            signer,
+            keccak256(bytes("VA001")),
+            keccak256(bytes("CLAIMCODE-001")),
+            uint256(0),
+            type(uint256).max,
+            bytes32(nonce)
+        );
+        (uint8 v, bytes32 r, bytes32 s) = _signDigestBytes(pk, data);
+
+        uint256 signerCTBefore = token.balanceOf(signer);
+        uint256 relayerPCEBefore = pceToken.balanceOf(relayer);
+        uint256 relayerCTBefore = token.balanceOf(relayer);
+
+        vm.prank(relayer);
+        token.claimVoucherWithAuthorization(
+            signer, "VA001", "CLAIMCODE-001", proof, 0, type(uint256).max, bytes32(nonce), v, r, s
+        );
+
+        assertGt(token.balanceOf(signer), signerCTBefore, "claimer should receive CT (minus fee)");
+        assertGt(pceToken.balanceOf(relayer), relayerPCEBefore, "relayer should receive PCE fee");
+        assertEq(token.balanceOf(relayer), relayerCTBefore, "relayer should NOT receive CT");
+    }
+
     // --- PIP-15: Message Count Parameter Tests ---
 
     function testTransferWithMessageCount() public {
@@ -825,6 +1074,7 @@ contract PCETest is Test {
 
         uint256 balanceAfterMsg5 = token.balanceOf(user1);
         // user1 should have less than before (sent 10) but may have arigato mint
+        assertLt(balanceAfterMsg5, balanceBefore, "user1 balance should decrease after sending tokens");
         uint256 user2Balance = token.balanceOf(user2);
         assertGt(user2Balance, 0, "user2 should have received tokens");
         vm.stopPrank();

--- a/test/PCE.t.sol
+++ b/test/PCE.t.sol
@@ -274,7 +274,184 @@ contract PCETest is Test {
     }
 
     function testVersion() public view {
-        assertEq(pceToken.version(), "1.0.12");
-        assertEq(token.version(), "1.0.12");
+        assertEq(pceToken.version(), "1.0.13");
+        assertEq(token.version(), "1.0.13");
+    }
+
+    // --- PIP-3: Meta-Transaction Fee Auto-Swap Tests ---
+
+    function _makeDomainSeparator(address tokenAddr) internal view returns (bytes32) {
+        return keccak256(
+            abi.encode(
+                keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"),
+                keccak256("PeaceBaseCoin"),
+                keccak256("1"),
+                block.chainid,
+                tokenAddr
+            )
+        );
+    }
+
+    function _buildTransferWithAuthDigest(
+        address from,
+        address to,
+        uint256 value,
+        uint256 validAfter,
+        uint256 validBefore,
+        bytes32 nonce
+    )
+        internal
+        view
+        returns (bytes32)
+    {
+        bytes32 domainSeparator = _makeDomainSeparator(address(token));
+        bytes32 structHash = keccak256(
+            abi.encode(
+                bytes32(0x7c7c6cdb67a18743f49ec6fa9b35f50d52ed05cbed4cc592e13b44501c1a2267),
+                from,
+                to,
+                value,
+                validAfter,
+                validBefore,
+                nonce
+            )
+        );
+        return keccak256(abi.encodePacked("\x19\x01", domainSeparator, structHash));
+    }
+
+    function testFeeSwapFromLocalToken() public {
+        // Setup: give community tokens to owner via swapToLocalToken
+        vm.startPrank(owner);
+        pceToken.swapToLocalToken(address(token), 100 ether);
+        vm.warp(block.timestamp + 1 days);
+        token.transfer(user1, 1 ether);
+        vm.warp(block.timestamp + 1 days);
+        vm.stopPrank();
+
+        address relayer = address(0x3);
+        uint256 displayAmount = 1 ether;
+
+        // Call swapFeeFromLocalToken directly as the community token contract
+        uint256 relayerPCEBefore = pceToken.balanceOf(relayer);
+
+        vm.prank(address(token));
+        uint256 pceAmount = pceToken.swapFeeFromLocalToken(address(token), relayer, displayAmount);
+
+        uint256 relayerPCEAfter = pceToken.balanceOf(relayer);
+        assertTrue(pceAmount > 0, "Should return non-zero PCE amount");
+        assertTrue(relayerPCEAfter > relayerPCEBefore, "Relayer should receive PCE");
+    }
+
+    function testSwapFeeFromLocalTokenOnlyCallableByCommunityToken() public {
+        // Non-community-token address should be rejected
+        vm.prank(user1);
+        vm.expectRevert("Caller must be the community token");
+        pceToken.swapFeeFromLocalToken(address(token), user1, 1 ether);
+    }
+
+    function testSwapFeeFromLocalTokenUnregisteredToken() public {
+        // Unregistered token address should be rejected
+        address fakeToken = address(0x999);
+        vm.prank(fakeToken);
+        vm.expectRevert("Token not registered");
+        pceToken.swapFeeFromLocalToken(fakeToken, user1, 1 ether);
+    }
+
+    function testFeeSwapBypassesDailyLimit() public {
+        vm.startPrank(owner);
+        pceToken.swapToLocalToken(address(token), 500 ether);
+
+        // Advance time for midnightBalance setup
+        vm.warp(block.timestamp + 1 days);
+        token.transfer(user1, 1 ether);
+        vm.warp(block.timestamp + 1 days);
+
+        // Exhaust daily swap limit via regular swaps
+        uint256 remaining = token.getRemainingSwapableToPCEBalance();
+        if (remaining > 0) {
+            pceToken.swapFromLocalToken(address(token), remaining);
+        }
+
+        // Verify regular swap now fails
+        vm.expectRevert("Exceeds daily swap limit");
+        pceToken.swapFromLocalToken(address(token), 1 ether);
+        vm.stopPrank();
+
+        // Fee swap should still work despite exhausted daily limit
+        address relayer = address(0x3);
+        uint256 relayerPCEBefore = pceToken.balanceOf(relayer);
+
+        vm.prank(address(token));
+        uint256 pceAmount = pceToken.swapFeeFromLocalToken(address(token), relayer, 0.01 ether);
+
+        assertTrue(pceAmount > 0, "Fee swap should succeed even when daily limit exhausted");
+        assertTrue(pceToken.balanceOf(relayer) > relayerPCEBefore, "Relayer should receive PCE");
+    }
+
+    function testFeeSwapDoesNotAffectDailyLimitCounters() public {
+        vm.startPrank(owner);
+        pceToken.swapToLocalToken(address(token), 100 ether);
+
+        vm.warp(block.timestamp + 1 days);
+        token.transfer(user1, 1 ether);
+        vm.warp(block.timestamp + 1 days);
+
+        uint256 globalRemainingBefore = token.getRemainingSwapableToPCEBalance();
+        vm.stopPrank();
+
+        // Do a fee swap
+        vm.prank(address(token));
+        pceToken.swapFeeFromLocalToken(address(token), address(0x3), 0.01 ether);
+
+        // Daily limit counters should be unchanged
+        uint256 globalRemainingAfter = token.getRemainingSwapableToPCEBalance();
+        assertEq(globalRemainingBefore, globalRemainingAfter, "Fee swap should not affect daily limit counters");
+    }
+
+    function testTransferWithAuthorizationFeeSwap() public {
+        // Setup: create signer with known private key
+        uint256 signerPrivateKey = 0xA11CE;
+        address signer = vm.addr(signerPrivateKey);
+        address relayer = address(0x3);
+
+        // Give signer community tokens
+        vm.startPrank(owner);
+        pceToken.swapToLocalToken(address(token), 200 ether);
+        vm.warp(block.timestamp + 1 days);
+        token.transfer(signer, 50 ether);
+        vm.warp(block.timestamp + 1 days);
+        vm.stopPrank();
+
+        // Build EIP712 signature for transferWithAuthorization
+        uint256 transferAmount = 5 ether;
+        bytes32 nonce = bytes32(uint256(1));
+        uint256 validAfter = 0;
+        uint256 validBefore = type(uint256).max;
+
+        bytes32 digest = _buildTransferWithAuthDigest(
+            signer, user2, transferAmount, validAfter, validBefore, nonce
+        );
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(signerPrivateKey, digest);
+
+        // Record balances before
+        uint256 relayerPCEBefore = pceToken.balanceOf(relayer);
+        uint256 relayerCTBefore = token.balanceOf(relayer);
+        uint256 user2CTBefore = token.balanceOf(user2);
+
+        // Execute as relayer
+        vm.prank(relayer);
+        token.transferWithAuthorization(
+            signer, user2, transferAmount, validAfter, validBefore, nonce, v, r, s
+        );
+
+        // Verify: relayer received PCE, NOT community tokens
+        uint256 relayerPCEAfter = pceToken.balanceOf(relayer);
+        uint256 relayerCTAfter = token.balanceOf(relayer);
+
+        assertTrue(relayerPCEAfter > relayerPCEBefore, "Relayer should receive PCE as fee");
+        assertEq(relayerCTAfter, relayerCTBefore, "Relayer should NOT receive community tokens");
+
+        // Verify: user2 received the transfer
+        assertTrue(token.balanceOf(user2) > user2CTBefore, "Recipient should receive community tokens");
     }
 }


### PR DESCRIPTION
## Summary

Ship **PIP-13** (Meta-Transaction Fee Auto-Swap to PCE) and **PIP-15** (Message Count Parameter for Arigato Creation) as a single on-chain upgrade proposal. Combining them pushed `PCECommunityToken` past the 24 KiB EIP-170 default, so this branch also refactors the contract to fit comfortably under **Polygon's 32 KiB limit** (raised by [PIP-30 / Ahmedabad hardfork](https://forum.polygon.technology/t/pip-30-increase-max-code-size-limit-to-32kb/13266), 2024-09-25).

Supersedes PRs **#31** (PIP-13 alone) and **#34** (PIP-15 alone) — each cannot ship on its own because even individually they exceed the pre-PIP-30 24 KiB limit after PIP-12 landed.

## Scope

- **PIP-13**: `PCEToken.swapFeeFromLocalToken` + new `_collectFeeAsPCE` helper wired into all meta-tx paths. Relayers always receive PCE as fee, regardless of which community token the tx is for. Exempt from daily swap limits.
- **PIP-15**: Four new `*WithMessageCount` entry points on `PCECommunityToken` that thread an explicit `messageCount` into `_mintArigatoCreation`. Pre-existing `transfer` / `transferFrom` unchanged.
- **Size-fit refactor**: three new linked libraries (`VoucherSystem` becomes public, plus new `TokenValueOps` and `ArigatoCreation`), helper consolidation (`_useAuthorization`, `_digest`), and dropping the unused `ERC20BurnableUpgradeable` inheritance.
- **`foundry.toml`**: `code_size_limit = 32768` so local sims match the chain.

## Contract sizes

| Contract | Bytes | Margin vs 32,768 |
|---|---:|---:|
| PCECommunityToken | 26,948 | 5,820 |
| PCEToken | 16,538 | 16,230 |
| VoucherSystem (lib) | 8,125 | 24,643 |
| TokenValueOps (lib) | 3,993 | 28,775 |
| ArigatoCreation (lib) | 1,730 | 31,038 |

## Public ABI preservation invariants

Verified by 4-agent multi-review (Claude / Codex / Gemini / Copilot, 3 iterations) that every pre-existing public state var / constant keeps its auto-getter, every public function keeps its selector and return shape, every `require("...")` message is unchanged, `transfer` / `transferFrom` emit no extra events, and `_transferWithAuthorization` in `EIP3009.sol` still uses the `"PeaceBaseCoin"` EIP-712 domain so v14 signatures remain valid. The only externally visible behaviour changes are:

1. Deployment now requires three additional library contracts to be deployed & linked (handled automatically by `forge script`).
2. `getMetaTransactionFee()` internally delegates to `getMetaTransactionFeeWithBaseFee(block.basefee)` — mathematically identical, same return value.

## Upgrade safety

Storage layout verified against **v14** via `PREV_TAG=v14 ./script/upgrade.sh script/DeployImpl.s.sol --fork-url polygon`. The script now passes `--unsafeAllow external-library-linking` to OZ's validator; libraries hold no storage of their own so layout is unaffected.

## Tests

**84 passing** (77 pre-existing + 7 new):
- `testTransferFromWithAuthorizationFeeSwap`
- `testTransferWithAuthorizationWithMessageCount`
- `testTransferWithAuthorizationWithMessageCountRejectsReplay`
- `testTransferFromWithAuthorizationWithMessageCount`
- `testSetInfinityApproveFlagWithAuthorizationFeeSwap`
- `testClaimVoucherWithAuthorizationRejectsReplay`
- `testClaimVoucherWithAuthorizationFeeSwap`

## Deployment plan

```bash
# 1. Build & size check
forge build --sizes

# 2. Storage layout validation
PREV_TAG=v14 ./script/upgrade.sh script/DeployImpl.s.sol --fork-url polygon

# 3. Real deploy — forge auto-deploys & links the libraries
source .env && forge script script/DeployImpl.s.sol --rpc-url polygon --broadcast

# 4. Verify all 5 contracts on Polygonscan

# 5. Create Tally proposal (two inner actions on Polygon Timelock):
#      a) PCEToken proxy         upgradeToAndCall(newPCEImpl, 0x)
#      b) PCECommunityToken beacon upgradeTo(newCommunityImpl)
#
# 6. After execute, tag release:
git tag v15
git push origin v15
```

## Test plan

- [x] `forge test` — 84 tests pass
- [x] `forge build --sizes` — all contracts under Polygon 32,768 limit
- [x] `PREV_TAG=v14 ./script/upgrade.sh … --fork-url polygon` — storage layout OK, deploy simulation OK
- [x] Multi-agent review (Claude, Codex, Gemini, Copilot) — 3 iterations, final round all-clear
- [ ] Deploy new impls on Polygon mainnet, verify on Polygonscan
- [ ] Construct Tally proposal via `script/verify-proposal.sh` shape
- [ ] Voter-side verification with `script/verify-proposal.sh <PID>` once proposed

🤖 Generated with [Claude Code](https://claude.com/claude-code)