### PR TITLE
feat: PIP-16 owner-controlled token value operations (supersedes PIP-12)

### DIFF
--- a/src/PCECommunityToken.sol
+++ b/src/PCECommunityToken.sol
@@ -113,10 +113,13 @@ contract PCECommunityToken is
     mapping(address => uint256) public swappedToPCETodayByAddress;
     mapping(address => uint256) public swappedToPCETodayByAddressModifiedTime;
 
-    // --- V14: Treasury wallet and token value operations (PIP-12) ---
-    address public treasuryWallet;
-    bytes32 public constant RATE_MANAGER_ROLE = keccak256("RATE_MANAGER_ROLE");
-    mapping(bytes32 => mapping(address => bool)) private _roles;
+    // --- V14: Treasury / role storage retained as deprecated for layout compatibility (PIP-12 → PIP-16) ---
+    /// @custom:oz-renamed-from treasuryWallet
+    address private __deprecated_treasuryWallet;
+    /// @custom:oz-renamed-from _roles
+    mapping(bytes32 => mapping(address => bool)) private __deprecated_roles;
+
+    // --- V14: Rebase factor for token splits (used by PIP-16) ---
     uint256 public rebaseFactor;
 
     event PCETransfer(address indexed from, address indexed to, uint256 displayAmount, uint256 rawAmount);
@@ -124,11 +127,6 @@ contract PCECommunityToken is
     event MetaTransactionFeeCollected(address indexed from, address indexed to, uint256 displayFee, uint256 rawFee);
     event MetaTransactionFeeSwapped(address indexed from, address indexed relayer, uint256 communityTokenFee, uint256 pceFee);
     event InfinityApproveFlagSet(address indexed owner, address indexed spender, bool flag);
-    event TreasuryWalletSet(address indexed wallet);
-    event TokenValueIncreased(uint256 pceAmount, uint256 oldExchangeRate, uint256 newExchangeRate);
-    event TokenSplit(uint256 mintAmount, uint256 oldExchangeRate, uint256 newExchangeRate, uint256 oldRebaseFactor, uint256 newRebaseFactor);
-    event RateManagerRoleGranted(address indexed account);
-    event RateManagerRoleRevoked(address indexed account);
     event TransferWithMessageCount(address indexed from, address indexed to, uint256 displayAmount, uint256 messageCount);
 
     function initialize(string memory name, string memory symbol, uint256 _initialFactor) public initializer {
@@ -926,43 +924,14 @@ contract PCECommunityToken is
         );
     }
 
-    // --- V14: Treasury wallet and token value operations (PIP-12) ---
+    // --- V16: PIP-16 internal coordination — only PCEToken can update rebase factor (during splitToken) ---
 
-    modifier onlyRateManager() {
-        require(_roles[RATE_MANAGER_ROLE][_msgSender()], "Not rate manager");
-        _;
-    }
-
-    function hasRole(bytes32 role, address account) public view returns (bool) {
-        return _roles[role][account];
-    }
-
-    function initializeTreasury(address wallet) external onlyOwner {
-        (treasuryWallet, rebaseFactor) =
-            TokenValueOps.initializeTreasury(treasuryWallet, wallet, _msgSender(), _roles, RATE_MANAGER_ROLE);
-    }
-
-    function setTreasuryWallet(address wallet) external onlyRateManager {
-        treasuryWallet = TokenValueOps.setTreasuryWallet(wallet);
-    }
-
-    function increaseTokenValue(uint256 pceAmount) external onlyRateManager {
-        TokenValueOps.increaseTokenValue(pceAmount, pceAddress, address(this), treasuryWallet);
-    }
-
-    function splitToken(uint256 mintAmount) external onlyRateManager {
-        rebaseFactor = TokenValueOps.splitToken(mintAmount, totalSupply(), rebaseFactor, pceAddress, address(this));
-    }
-
-    function grantRateManagerRole(address account) external onlyRateManager {
-        TokenValueOps.grantRateManagerRole(account, _roles, RATE_MANAGER_ROLE);
-    }
-
-    function revokeRateManagerRole(address account) external onlyRateManager {
-        TokenValueOps.revokeRateManagerRole(account, _roles, RATE_MANAGER_ROLE);
+    function applyRebase(uint256 newFactor) external {
+        require(_msgSender() == pceAddress, "Only PCE token");
+        rebaseFactor = newFactor;
     }
 
     function version() public pure returns (string memory) {
-        return "1.0.15";
+        return "1.0.16";
     }
 }

--- a/src/PCEToken.sol
+++ b/src/PCEToken.sol
@@ -49,6 +49,17 @@ contract PCEToken is
     event FeeSwappedFromLocalToken(
         address indexed fromToken, address indexed relayer, uint256 communityTokenAmount, uint256 pceAmount
     );
+    event TokenValueIncreased(
+        address indexed communityToken, uint256 pceAmount, uint256 oldExchangeRate, uint256 newExchangeRate
+    );
+    event TokenSplit(
+        address indexed communityToken,
+        uint256 mintAmount,
+        uint256 oldExchangeRate,
+        uint256 newExchangeRate,
+        uint256 oldRebaseFactor,
+        uint256 newRebaseFactor
+    );
 
     uint256 public constant INITIAL_FACTOR = 10 ** 18;
     uint256 private constant Q96 = 2 ** 96;
@@ -426,35 +437,55 @@ contract PCEToken is
         _burn(_msgSender(), amount);
     }
 
-    function addReserve(address communityToken, uint256 pceAmount, address _treasuryWallet) external {
-        require(msg.sender == communityToken, "Only community token");
-        require(localTokens[communityToken].isExists, "Token not found");
+    function increaseTokenValue(address communityToken, uint256 pceAmount) external {
+        require(localTokens[communityToken].isExists, "Target token not found");
+        require(_msgSender() == OwnableUpgradeable(communityToken).owner(), "Only community owner");
         require(pceAmount > 0, "Amount must be > 0");
+
+        updateFactorIfNeeded();
 
         uint256 oldDeposited = localTokens[communityToken].depositedPCEToken;
         uint256 oldRate = localTokens[communityToken].exchangeRate;
 
-        // Transfer PCE from treasury wallet to this contract (requires prior approve)
-        _spendAllowance(_treasuryWallet, address(this), pceAmount);
-        _transfer(_treasuryWallet, address(this), pceAmount);
+        _transfer(_msgSender(), address(this), pceAmount);
 
-        // Update deposited amount
+        // When reserves are fully drained the proportional formula collapses to zero, which would
+        // brick all future swaps. Fall back to keeping the prior rate so the community can recover.
+        uint256 newRate = oldDeposited == 0
+            ? oldRate
+            : Math.mulDiv(oldRate, oldDeposited, oldDeposited + pceAmount);
         localTokens[communityToken].depositedPCEToken = oldDeposited + pceAmount;
+        localTokens[communityToken].exchangeRate = newRate;
 
-        // Adjust exchange rate: newRate = oldRate * oldDeposited / (oldDeposited + pceAmount)
-        localTokens[communityToken].exchangeRate = Math.mulDiv(oldRate, oldDeposited, oldDeposited + pceAmount);
+        emit TokenValueIncreased(communityToken, pceAmount, oldRate, newRate);
     }
 
-    function adjustExchangeRate(address communityToken, uint256 newRate) external {
-        require(msg.sender == communityToken, "Only community token");
-        require(localTokens[communityToken].isExists, "Token not found");
-        require(newRate > 0, "Rate must be > 0");
+    function splitToken(address communityToken, uint256 mintAmount) external {
+        require(localTokens[communityToken].isExists, "Target token not found");
+        require(_msgSender() == OwnableUpgradeable(communityToken).owner(), "Only community owner");
+        require(mintAmount > 0, "Amount must be > 0");
+
+        updateFactorIfNeeded();
+
+        PCECommunityToken target = PCECommunityToken(communityToken);
+        uint256 currentSupply = target.totalSupply();
+        require(currentSupply > 0, "No supply to split");
+
+        uint256 oldRebase = target.rebaseFactor();
+        if (oldRebase == 0) oldRebase = INITIAL_FACTOR;
+        uint256 newRebase = Math.mulDiv(oldRebase, currentSupply + mintAmount, currentSupply);
+        target.applyRebase(newRebase);
+
+        uint256 oldRate = localTokens[communityToken].exchangeRate;
+        uint256 newRate = Math.mulDiv(oldRate, newRebase, oldRebase);
         localTokens[communityToken].exchangeRate = newRate;
+
+        emit TokenSplit(communityToken, mintAmount, oldRate, newRate, oldRebase, newRebase);
     }
 
     function _authorizeUpgrade(address newImplementation) internal virtual override onlyOwner { }
 
     function version() public pure returns (string memory) {
-        return "1.0.14";
+        return "1.0.15";
     }
 }

--- a/src/lib/TokenValueOps.sol
+++ b/src/lib/TokenValueOps.sol
@@ -7,18 +7,6 @@ import { PCEToken } from "../PCEToken.sol";
 import { Utils } from "./Utils.sol";
 
 library TokenValueOps {
-    event TreasuryWalletSet(address indexed wallet);
-    event TokenValueIncreased(uint256 pceAmount, uint256 oldExchangeRate, uint256 newExchangeRate);
-    event TokenSplit(
-        uint256 mintAmount,
-        uint256 oldExchangeRate,
-        uint256 newExchangeRate,
-        uint256 oldRebaseFactor,
-        uint256 newRebaseFactor
-    );
-    event RateManagerRoleGranted(address indexed account);
-    event RateManagerRoleRevoked(address indexed account);
-
     function computeSwapAmount(
         address pceAddress,
         address fromCommunityToken,
@@ -80,94 +68,5 @@ library TokenValueOps {
             return true;
         }
         revert("Invalid exchangeAllowMethod");
-    }
-
-    function initializeTreasury(
-        address currentTreasury,
-        address wallet,
-        address sender,
-        mapping(bytes32 => mapping(address => bool)) storage roles,
-        bytes32 role
-    )
-        public
-        returns (address newTreasury, uint256 newRebaseFactor)
-    {
-        require(currentTreasury == address(0), "Already initialized");
-        require(wallet != address(0), "Invalid wallet address");
-        roles[role][sender] = true;
-        emit TreasuryWalletSet(wallet);
-        emit RateManagerRoleGranted(sender);
-        return (wallet, 10 ** 18);
-    }
-
-    function setTreasuryWallet(address wallet) public returns (address) {
-        require(wallet != address(0), "Invalid wallet address");
-        emit TreasuryWalletSet(wallet);
-        return wallet;
-    }
-
-    function increaseTokenValue(
-        uint256 pceAmount,
-        address pceAddress,
-        address self,
-        address treasuryWallet
-    )
-        public
-    {
-        require(pceAmount > 0, "Amount must be > 0");
-        PCEToken pceToken = PCEToken(pceAddress);
-        uint256 oldExchangeRate = pceToken.getExchangeRate(self);
-        pceToken.addReserve(self, pceAmount, treasuryWallet);
-        uint256 newExchangeRate = pceToken.getExchangeRate(self);
-        emit TokenValueIncreased(pceAmount, oldExchangeRate, newExchangeRate);
-    }
-
-    function splitToken(
-        uint256 mintAmount,
-        uint256 currentTotalDisplay,
-        uint256 oldRebaseFactor,
-        address pceAddress,
-        address self
-    )
-        public
-        returns (uint256 newRebaseFactor)
-    {
-        require(mintAmount > 0, "Amount must be > 0");
-        require(currentTotalDisplay > 0, "No supply to split");
-
-        PCEToken pceToken = PCEToken(pceAddress);
-        uint256 oldExchangeRate = pceToken.getExchangeRate(self);
-
-        newRebaseFactor = Math.mulDiv(oldRebaseFactor, currentTotalDisplay + mintAmount, currentTotalDisplay);
-
-        uint256 newRate = Math.mulDiv(oldExchangeRate, newRebaseFactor, oldRebaseFactor);
-        pceToken.adjustExchangeRate(self, newRate);
-
-        uint256 newExchangeRate = pceToken.getExchangeRate(self);
-        emit TokenSplit(mintAmount, oldExchangeRate, newExchangeRate, oldRebaseFactor, newRebaseFactor);
-    }
-
-    function grantRateManagerRole(
-        address account,
-        mapping(bytes32 => mapping(address => bool)) storage roles,
-        bytes32 role
-    )
-        public
-    {
-        require(account != address(0), "Invalid account address");
-        roles[role][account] = true;
-        emit RateManagerRoleGranted(account);
-    }
-
-    function revokeRateManagerRole(
-        address account,
-        mapping(bytes32 => mapping(address => bool)) storage roles,
-        bytes32 role
-    )
-        public
-    {
-        require(account != address(0), "Invalid account address");
-        roles[role][account] = false;
-        emit RateManagerRoleRevoked(account);
     }
 }

--- a/test/PCE.t.sol
+++ b/test/PCE.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.30;
 
-import {Test, console2} from "forge-std/Test.sol";
+import {Test, console2, StdStorage, stdStorage} from "forge-std/Test.sol";
 import {PCECommunityToken} from "../src/PCECommunityToken.sol";
 import {PCEToken} from "../src/PCEToken.sol";
 import {ExchangeAllowMethod} from "../src/lib/Enum.sol";
@@ -23,6 +23,8 @@ contract MinimalBeacon {
 }
 
 contract PCETest is Test {
+    using stdStorage for StdStorage;
+
     PCEToken public pceToken;
     PCECommunityToken public token;
     MinimalBeacon public pceCommunityTokenBeacon;
@@ -349,107 +351,45 @@ contract PCETest is Test {
     }
 
     function testVersion() public view {
-        assertEq(pceToken.version(), "1.0.14");
-        assertEq(token.version(), "1.0.15");
+        assertEq(pceToken.version(), "1.0.15");
+        assertEq(token.version(), "1.0.16");
     }
 
-    // --- PIP-12: Treasury wallet and token value operations tests ---
-
-    function _setupTreasury() internal {
-        // Create a treasury wallet address
-        address treasury = address(0x1234);
-
-        // Owner initializes treasury on the community token
-        vm.startPrank(owner);
-        token.initializeTreasury(treasury);
-        vm.stopPrank();
-    }
-
-    function _setupTreasuryWithDeposit() internal returns (address treasury) {
-        treasury = address(0x1234);
-
-        vm.startPrank(owner);
-        token.initializeTreasury(treasury);
-
-        // Give treasury wallet some PCE tokens and approve PCEToken contract
-        pceToken.transfer(treasury, 200 ether);
-        vm.stopPrank();
-
-        vm.startPrank(treasury);
-        pceToken.approve(address(pceToken), type(uint256).max);
-        vm.stopPrank();
-    }
-
-    function testInitializeTreasury() public {
-        address treasury = address(0x1234);
-
-        vm.startPrank(owner);
-        token.initializeTreasury(treasury);
-        vm.stopPrank();
-
-        // Treasury wallet should be set
-        assertEq(token.treasuryWallet(), treasury, "Treasury wallet should be set");
-
-        // Owner should have RATE_MANAGER_ROLE
-        assertTrue(
-            token.hasRole(token.RATE_MANAGER_ROLE(), owner),
-            "Owner should have rate manager role"
-        );
-    }
-
-    function testInitializeTreasuryCannotBeCalledTwice() public {
-        address treasury = address(0x1234);
-
-        vm.startPrank(owner);
-        token.initializeTreasury(treasury);
-
-        vm.expectRevert("Already initialized");
-        token.initializeTreasury(address(0x5678));
-        vm.stopPrank();
-    }
+    // --- PIP-16: Owner-controlled token value operations tests ---
 
     function testIncreaseTokenValue() public {
-        address treasury = _setupTreasuryWithDeposit();
-
         // Initial state: depositedPCEToken=1000e18 (from createToken), exchangeRate=1e18
         uint256 depositedBefore = pceToken.getDepositedPCETokens(address(token));
         uint256 rateBefore = pceToken.getExchangeRate(address(token));
         assertEq(depositedBefore, 1000 ether, "Initial deposited should be 1000e18");
         assertEq(rateBefore, 1 ether, "Initial exchange rate should be 1e18");
 
-        uint256 treasuryBalanceBefore = pceToken.balanceOf(treasury);
+        uint256 ownerBalanceBefore = pceToken.balanceOf(owner);
         uint256 increaseAmount = 100 ether;
 
-        // Increase token value by 100e18 (treasury has 200 PCE)
         vm.startPrank(owner);
-        token.increaseTokenValue(increaseAmount);
+        pceToken.increaseTokenValue(address(token), increaseAmount);
         vm.stopPrank();
 
         uint256 depositedAfter = pceToken.getDepositedPCETokens(address(token));
         uint256 rateAfter = pceToken.getExchangeRate(address(token));
-        uint256 treasuryBalanceAfter = pceToken.balanceOf(treasury);
+        uint256 ownerBalanceAfter = pceToken.balanceOf(owner);
 
-        // depositedPCEToken should be 1100e18
         assertEq(depositedAfter, depositedBefore + increaseAmount, "Deposited should increase");
 
-        // exchangeRate = 1e18 * 1000e18 / 1100e18
         uint256 expectedRate = (rateBefore * depositedBefore) / (depositedBefore + increaseAmount);
         assertEq(rateAfter, expectedRate, "Exchange rate should be adjusted downward");
 
-        // Treasury balance should decrease by increaseAmount
         assertEq(
-            treasuryBalanceBefore - treasuryBalanceAfter,
+            ownerBalanceBefore - ownerBalanceAfter,
             increaseAmount,
-            "Treasury should have sent PCE"
+            "Owner should have paid PCE for the reserve"
         );
     }
 
     function testIncreaseTokenValueWithSmallDeposit() public {
-        // Test with deposited=100e18, rate=1e18, increase=50e18
-
         vm.startPrank(owner);
 
-        // Create a new community token with 100e18 deposit
         address[] memory incomeTargetTokens = new address[](0);
         address[] memory outgoTargetTokens = new address[](0);
 
@@ -468,31 +408,14 @@ contract PCETest is Test {
         address[] memory tokens_ = pceToken.getTokens();
         PCECommunityToken smallToken = PCECommunityToken(tokens_[tokens_.length - 1]);
 
-        // Set up treasury
-        address treasury = address(0x5678);
-        smallToken.initializeTreasury(treasury);
-
-        // Give treasury 50 PCE and approve
-        pceToken.transfer(treasury, 50 ether);
-        vm.stopPrank();
-
-        vm.startPrank(treasury);
-        pceToken.approve(address(pceToken), type(uint256).max);
-        vm.stopPrank();
-
-        // Verify initial state
         assertEq(pceToken.getDepositedPCETokens(address(smallToken)), 100 ether);
         assertEq(pceToken.getExchangeRate(address(smallToken)), 1 ether);
 
-        // Increase token value by 50e18
-        vm.startPrank(owner);
-        smallToken.increaseTokenValue(50 ether);
+        pceToken.increaseTokenValue(address(smallToken), 50 ether);
         vm.stopPrank();
 
-        // depositedPCEToken = 150e18
         assertEq(pceToken.getDepositedPCETokens(address(smallToken)), 150 ether);
 
-        // exchangeRate = 1e18 * 100e18 / 150e18 = 666666666666666666 (~0.667e18)
         uint256 rateNum = 1 ether * 100 ether;
         uint256 rateDen = 150 ether;
         uint256 expectedRate = rateNum / rateDen;
@@ -500,7 +423,6 @@ contract PCETest is Test {
     }
 
     function testSplitToken() public {
-        // Test stock-split: totalSupply=100 tokens, mint 25 more → rebaseFactor increases
         vm.startPrank(owner);
 
         address[] memory incomeTargetTokens = new address[](0);
@@ -521,112 +443,83 @@ contract PCETest is Test {
         address[] memory tokens_ = pceToken.getTokens();
         PCECommunityToken sToken = PCECommunityToken(tokens_[tokens_.length - 1]);
 
-        address treasury = address(0x9999);
-        sToken.initializeTreasury(treasury);
-
         uint256 rateBefore = pceToken.getExchangeRate(address(sToken));
-        uint256 rebaseFactorBefore = sToken.rebaseFactor();
         uint256 totalSupplyBefore = sToken.totalSupply();
+        uint256 rebaseFactorBefore = sToken.rebaseFactor() == 0
+            ? sToken.INITIAL_FACTOR()
+            : sToken.rebaseFactor();
 
-        // Split: mint 25 tokens worth
         uint256 mintAmount = 25 ether;
-        sToken.splitToken(mintAmount);
+        pceToken.splitToken(address(sToken), mintAmount);
         vm.stopPrank();
 
         uint256 rebaseFactorAfter = sToken.rebaseFactor();
         uint256 rateAfter = pceToken.getExchangeRate(address(sToken));
         uint256 totalSupplyAfter = sToken.totalSupply();
 
-        // rebaseFactor should increase: old * (total + mint) / total
         uint256 expectedRebaseFactor = (rebaseFactorBefore * (totalSupplyBefore + mintAmount)) / totalSupplyBefore;
         assertEq(rebaseFactorAfter, expectedRebaseFactor, "Rebase factor should increase proportionally");
 
-        // exchangeRate should increase: old * newRebase / oldRebase
         uint256 expectedRate = (rateBefore * rebaseFactorAfter) / rebaseFactorBefore;
         assertEq(rateAfter, expectedRate, "Exchange rate should adjust for split");
 
-        // Total supply should increase by mintAmount
         assertEq(totalSupplyAfter, totalSupplyBefore + mintAmount, "Total supply should increase");
     }
 
     function testSplitTokenZeroAmountReverts() public {
-        _setupTreasury();
-
         vm.startPrank(owner);
         vm.expectRevert("Amount must be > 0");
-        token.splitToken(0);
+        pceToken.splitToken(address(token), 0);
         vm.stopPrank();
     }
 
     function testUnauthorizedAccess() public {
-        _setupTreasury();
-
-        // user1 (not a rate manager) tries to call increaseTokenValue
         vm.startPrank(user1);
-        vm.expectRevert("Not rate manager");
-        token.increaseTokenValue(10 ether);
+        vm.expectRevert("Only community owner");
+        pceToken.increaseTokenValue(address(token), 10 ether);
 
-        vm.expectRevert("Not rate manager");
-        token.splitToken(10 ether);
-
-        vm.expectRevert("Not rate manager");
-        token.setTreasuryWallet(address(0x5555));
-
-        vm.expectRevert("Not rate manager");
-        token.grantRateManagerRole(user2);
-
-        vm.expectRevert("Not rate manager");
-        token.revokeRateManagerRole(owner);
-        vm.stopPrank();
-
-        // user1 tries to call initializeTreasury (not owner)
-        vm.startPrank(user1);
-        vm.expectRevert();
-        token.initializeTreasury(address(0x6666));
+        vm.expectRevert("Only community owner");
+        pceToken.splitToken(address(token), 10 ether);
         vm.stopPrank();
     }
 
-    function testRoleManagement() public {
-        _setupTreasury();
-
-        // Owner has rate manager role after initializeTreasury
-        assertTrue(
-            token.hasRole(token.RATE_MANAGER_ROLE(), owner),
-            "Owner should have rate manager role"
-        );
-
-        // Owner grants role to user1
-        vm.startPrank(owner);
-        token.grantRateManagerRole(user1);
-        vm.stopPrank();
-
-        assertTrue(
-            token.hasRole(token.RATE_MANAGER_ROLE(), user1),
-            "User1 should have rate manager role"
-        );
-
-        // User1 can now revoke owner's role
+    function testApplyRebaseOnlyCallableByPCEToken() public {
         vm.startPrank(user1);
-        token.revokeRateManagerRole(owner);
+        vm.expectRevert("Only PCE token");
+        token.applyRebase(2 ether);
         vm.stopPrank();
+    }
 
-        assertFalse(
-            token.hasRole(token.RATE_MANAGER_ROLE(), owner),
-            "Owner should no longer have rate manager role"
-        );
+    function testIncreaseTokenValueAfterReserveDrainedToZero() public {
+        // Force depositedPCEToken to 0 via storage manipulation. This is the post-condition
+        // when all reserves have been swapped out via swapFromLocalToken / swapFeeFromLocalToken.
+        stdstore
+            .target(address(pceToken))
+            .sig("getDepositedPCETokens(address)")
+            .with_key(address(token))
+            .checked_write(uint256(0));
+        assertEq(pceToken.getDepositedPCETokens(address(token)), 0, "Reserve should be drained");
 
-        // Owner can no longer call rate manager functions
+        uint256 rateBefore = pceToken.getExchangeRate(address(token));
+        assertGt(rateBefore, 0, "Pre-condition: exchange rate should still be positive");
+
+        uint256 increaseAmount = 100 ether;
         vm.startPrank(owner);
-        vm.expectRevert("Not rate manager");
-        token.increaseTokenValue(10 ether);
+        pceToken.increaseTokenValue(address(token), increaseAmount);
         vm.stopPrank();
 
-        // User1 can still call rate manager functions (setTreasuryWallet)
-        vm.startPrank(user1);
-        token.setTreasuryWallet(address(0x7777));
-        vm.stopPrank();
-
-        assertEq(token.treasuryWallet(), address(0x7777), "Treasury wallet should be updated");
+        assertEq(
+            pceToken.getDepositedPCETokens(address(token)),
+            increaseAmount,
+            "Reserve should recover from zero"
+        );
+        // With oldDeposited == 0, the contract must keep the prior exchangeRate so future swaps
+        // don't divide by (or mint) zero PCE.
+        assertEq(
+            pceToken.getExchangeRate(address(token)),
+            rateBefore,
+            "Exchange rate should remain at the prior value when refilling drained reserve"
+        );
     }
 
     // --- PIP-13: Meta-Transaction Fee Auto-Swap Tests ---


### PR DESCRIPTION
## Summary

Implementation of [PIP-16](https://github.com/peacecoin-protocol/PIPs/pull/11) (supersedes PIP-12).

- Move `increaseTokenValue` and `splitToken` to **PCEToken** (next to existing swap functions and the `depositedPCEToken` / `exchangeRate` state they mutate)
- Gate by community-owner check: `require(msg.sender == OwnableUpgradeable(communityToken).owner())`
- PCE pulled directly from `msg.sender` via PCEToken's internal `_transfer` — **no prior `approve` required**
- Add `PCECommunityToken.applyRebase(uint256)` as the single new internal-coordination function (gated to PCEToken, same convention as existing `mint` / `burnByPCEToken` / `recordSwapToPCE`)
- Remove all PIP-12 admin functions (`initializeTreasury`, `setTreasuryWallet`, `grantRateManagerRole`, `revokeRateManagerRole`, `hasRole`) and the `RATE_MANAGER_ROLE` / `_roles` machinery

## PIP-12 cleanup

PIP-12 was cancelled on the Polygon Timelock before its Beacon implementation switch executed (cancellation tx `0xe4ed89b0846ce643b29b528e1e2fbe247a51867235ba88cf1760fd944661e1fb`). PR #30 will be closed; PIP-12 will be marked Withdrawn in a follow-up PR on the PIPs repo.

## Storage layout compatibility

DEV had already been upgraded directly to a v15 implementation that committed PIP-12's `treasuryWallet` and `_roles` slots. To allow a single v16 implementation to upgrade both DEV and Production cleanly, PIP-12's slots are retained on PCECommunityToken as `__deprecated_*` private placeholders (with `@custom:oz-renamed-from` annotations).

OpenZeppelin upgrade-safety validation (via `script/upgrade.sh` machinery):

| | from v15 (DEV baseline) | from v13 / v12 (Production baseline) |
|---|---|---|
| PCECommunityToken | ✅ SUCCESS | ✅ SUCCESS |
| PCEToken | ✅ SUCCESS | ✅ SUCCESS |

## Versions

- PCEToken: `1.0.14` → `1.0.15`
- PCECommunityToken: `1.0.15` → `1.0.16`

## Bytecode

| | runtime size | margin (Polygon 32 KB) |
|---|---:|---:|
| PCECommunityToken (before, v15 = PIP-12 implementation) | 26,954 | 5,814 |
| PCECommunityToken (after, v16) | **25,425** | **7,343** |
| PCEToken (after, v15) | 17,148 | 15,620 |

PCECommunityToken: -1,529 bytes (PIP-12 admin functions removed + ops moved to PCEToken).

## Test plan

- [x] `forge build` passes
- [x] `forge test` — all 82 tests pass
- [x] OZ storage layout check passes from both DEV (v15) and Production (v13 / v12) baselines
- [ ] DEV upgrade dry-run (manual)
- [ ] Production upgrade proposal authored (Tally)

## Files changed

- `src/PCEToken.sol`: add `increaseTokenValue` / `splitToken` / `TokenValueIncreased` / `TokenSplit`; remove `addReserve` / `adjustExchangeRate`
- `src/PCECommunityToken.sol`: remove `increaseTokenValue` / `splitToken` / role machinery; add `applyRebase`; rename PIP-12 storage to `__deprecated_*`
- `src/lib/TokenValueOps.sol`: drop `increaseTokenValue` / `splitToken` / events (keep `computeSwapAmount` / `isAllowExchange`)
- `test/PCE.t.sol`: rewrite PIP-16 tests against new `pceToken.X(community, ...)` interface; remove approval-related setup