### PR TITLE
feat: PIP-17 Deposit Migration on Inter-community Swap

### DIFF
--- a/src/PCECommunityToken.sol
+++ b/src/PCECommunityToken.sol
@@ -435,7 +435,8 @@ contract PCECommunityToken is
     function swapTokens(address toTokenAddress, uint256 amountToSwap) public {
         address sender = _msgSender();
         updateFactorIfNeeded();
-        PCEToken(pceAddress).updateFactorIfNeeded();
+        PCEToken pceToken = PCEToken(pceAddress);
+        pceToken.updateFactorIfNeeded();
         PCECommunityToken to = PCECommunityToken(toTokenAddress);
         to.updateFactorIfNeeded();
 
@@ -447,7 +448,10 @@ contract PCECommunityToken is
             pceAddress, address(this), toTokenAddress, amountToSwap, getCurrentFactor(), to.getCurrentFactor()
         );
         super._burn(sender, displayBalanceToRawBalance(amountToSwap));
-        to.mint(sender, targetTokenAmount);
+
+        pceToken.executeInterCommunitySwap(
+            address(this), toTokenAddress, sender, amountToSwap, targetTokenAmount
+        );
     }
 
     function getMetaTransactionFee() public view returns (uint256) {

--- a/src/PCEToken.sol
+++ b/src/PCEToken.sol
@@ -49,6 +49,9 @@ contract PCEToken is
     event FeeSwappedFromLocalToken(
         address indexed fromToken, address indexed relayer, uint256 communityTokenAmount, uint256 pceAmount
     );
+    event DepositTransferredOnInterCommunitySwap(
+        address indexed fromToken, address indexed toToken, uint256 fromDisplayAmount, uint256 movedPceAmount
+    );
 
     uint256 public constant INITIAL_FACTOR = 10 ** 18;
     uint256 private constant Q96 = 2 ** 96;
@@ -347,6 +350,47 @@ contract PCEToken is
         emit FeeSwappedFromLocalToken(fromToken, relayer, communityTokenDisplayAmount, pcetokenAmount);
 
         return pcetokenAmount;
+    }
+
+    function executeInterCommunitySwap(
+        address fromToken,
+        address toToken,
+        address recipient,
+        uint256 fromDisplayAmount,
+        uint256 toDisplayAmount
+    )
+        external
+        returns (uint256)
+    {
+        require(msg.sender == fromToken, "Caller must be the from-side community token");
+        require(localTokens[fromToken].isExists, "From token not registered");
+        require(localTokens[toToken].isExists, "To token not registered");
+        require(fromToken != toToken, "Same-token swap");
+
+        updateFactorIfNeeded();
+
+        PCECommunityToken from = PCECommunityToken(fromToken);
+
+        uint256 movedPceAmount = Math.mulDiv(
+            Math.mulDiv(fromDisplayAmount, INITIAL_FACTOR, localTokens[fromToken].exchangeRate),
+            lastModifiedFactor,
+            from.getCurrentFactor()
+        );
+
+        if (movedPceAmount > 0) {
+            require(
+                localTokens[fromToken].depositedPCEToken >= movedPceAmount,
+                "Insufficient deposited PCE token reserve at source community"
+            );
+            localTokens[fromToken].depositedPCEToken -= movedPceAmount;
+            localTokens[toToken].depositedPCEToken += movedPceAmount;
+        }
+
+        PCECommunityToken(toToken).mint(recipient, toDisplayAmount);
+
+        emit DepositTransferredOnInterCommunitySwap(fromToken, toToken, fromDisplayAmount, movedPceAmount);
+
+        return movedPceAmount;
     }
 
     function getNativeTokenToPceTokenRate() public view returns (uint256) {

--- a/test/InterCommunitySwap.t.sol
+++ b/test/InterCommunitySwap.t.sol
@@ -1,0 +1,213 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.30;
+
+import {Test} from "forge-std/Test.sol";
+import {PCECommunityToken} from "../src/PCECommunityToken.sol";
+import {PCEToken} from "../src/PCEToken.sol";
+import {ExchangeAllowMethod} from "../src/lib/Enum.sol";
+
+contract MinimalBeacon {
+    address public implementation;
+    address public owner;
+
+    constructor(address initialImplementation) {
+        implementation = initialImplementation;
+        owner = msg.sender;
+    }
+
+    function upgradeTo(address newImplementation) public {
+        require(msg.sender == owner, "Ownable: caller is not the owner");
+        implementation = newImplementation;
+    }
+}
+
+contract InterCommunitySwapTest is Test {
+    PCEToken public pceToken;
+    PCECommunityToken public tokenA;
+    PCECommunityToken public tokenB;
+    MinimalBeacon public beacon;
+
+    address public owner;
+    address public user1;
+    address public user2;
+
+    uint256 constant INITIAL_DEPOSIT_A = 1000 ether;
+    uint256 constant INITIAL_DEPOSIT_B = 500 ether;
+
+    event DepositTransferredOnInterCommunitySwap(
+        address indexed fromToken, address indexed toToken, uint256 fromDisplayAmount, uint256 movedPceAmount
+    );
+
+    function setUp() public {
+        owner = address(this);
+        user1 = address(0x1);
+        user2 = address(0x2);
+
+        vm.startPrank(owner);
+
+        PCECommunityToken communityImpl = new PCECommunityToken();
+        beacon = new MinimalBeacon(address(communityImpl));
+
+        pceToken = new PCEToken();
+        pceToken.initialize();
+
+        // V1-storage simulation matching PCE.t.sol setUp
+        vm.store(address(pceToken), bytes32(uint256(3)), bytes32(uint256(396140812571321687967719751680)));
+        vm.store(address(pceToken), bytes32(uint256(4)), bytes32(uint256(200000)));
+        vm.store(address(pceToken), bytes32(uint256(5)), bytes32(uint256(50000000000)));
+        vm.store(address(pceToken), bytes32(uint256(6)), bytes32(uint256(300)));
+        vm.store(address(pceToken), bytes32(uint256(7)), bytes32(uint256(300)));
+
+        pceToken.setCommunityTokenAddress(address(beacon));
+        pceToken.mint(owner, 100000 ether);
+
+        address[] memory empty = new address[](0);
+
+        pceToken.createToken(
+            "Community A", "CA",
+            INITIAL_DEPOSIT_A,
+            1 ether,
+            1, 9800, 1000, 500, 1000, 100,
+            ExchangeAllowMethod.All, ExchangeAllowMethod.All,
+            empty, empty
+        );
+        pceToken.createToken(
+            "Community B", "CB",
+            INITIAL_DEPOSIT_B,
+            1 ether,
+            1, 9800, 1000, 500, 1000, 100,
+            ExchangeAllowMethod.All, ExchangeAllowMethod.All,
+            empty, empty
+        );
+
+        vm.stopPrank();
+
+        address[] memory tokens_ = pceToken.getTokens();
+        tokenA = PCECommunityToken(tokens_[0]);
+        tokenB = PCECommunityToken(tokens_[1]);
+    }
+
+    function _expectedMovedPce(uint256 displayAmount) internal view returns (uint256) {
+        uint256 a = (displayAmount * pceToken.INITIAL_FACTOR()) / pceToken.getExchangeRate(address(tokenA));
+        return (a * pceToken.lastModifiedFactor()) / tokenA.getCurrentFactor();
+    }
+
+    function testInterCommunitySwapMovesDeposit() public {
+        vm.startPrank(owner);
+
+        uint256 depositABefore = pceToken.getDepositedPCETokens(address(tokenA));
+        uint256 depositBBefore = pceToken.getDepositedPCETokens(address(tokenB));
+        assertEq(depositABefore, INITIAL_DEPOSIT_A);
+        assertEq(depositBBefore, INITIAL_DEPOSIT_B);
+
+        uint256 swapAmount = 30 ether;
+        uint256 expectedMoved = _expectedMovedPce(swapAmount);
+
+        tokenA.swapTokens(address(tokenB), swapAmount);
+
+        assertEq(pceToken.getDepositedPCETokens(address(tokenA)), depositABefore - expectedMoved);
+        assertEq(pceToken.getDepositedPCETokens(address(tokenB)), depositBBefore + expectedMoved);
+
+        vm.stopPrank();
+    }
+
+    function testTotalDepositInvariantUnderInterCommunitySwap() public {
+        vm.startPrank(owner);
+
+        uint256 totalBefore =
+            pceToken.getDepositedPCETokens(address(tokenA)) + pceToken.getDepositedPCETokens(address(tokenB));
+
+        tokenA.swapTokens(address(tokenB), 50 ether);
+        tokenB.swapTokens(address(tokenA), 10 ether);
+        tokenA.swapTokens(address(tokenB), 7 ether);
+
+        uint256 totalAfter =
+            pceToken.getDepositedPCETokens(address(tokenA)) + pceToken.getDepositedPCETokens(address(tokenB));
+
+        assertEq(totalAfter, totalBefore, "Total per-community deposit must be invariant under inter-community swaps");
+
+        vm.stopPrank();
+    }
+
+    function testDirectAndIndirectPathsProduceSameDeposits() public {
+        // Pre-stage time so both paths see the same decay state. swapFromLocalToken needs
+        // a midnight balance, which requires a warp + transfer + warp before the snapshot.
+        vm.startPrank(owner);
+        vm.warp(block.timestamp + 1 days);
+        tokenA.transfer(user1, 1 wei);
+        vm.warp(block.timestamp + 1 days);
+        vm.stopPrank();
+
+        uint256 swapAmount = 25 ether;
+        uint256 snapshotId = vm.snapshotState();
+
+        // Direct path
+        vm.startPrank(owner);
+        tokenA.swapTokens(address(tokenB), swapAmount);
+        uint256 directDepositA = pceToken.getDepositedPCETokens(address(tokenA));
+        uint256 directDepositB = pceToken.getDepositedPCETokens(address(tokenB));
+        vm.stopPrank();
+
+        vm.revertToState(snapshotId);
+
+        // Indirect path: A -> PCE -> B (must use the actual PCE returned by swapFromLocalToken)
+        vm.startPrank(owner);
+        uint256 pceBalanceBefore = pceToken.balanceOf(owner);
+        pceToken.swapFromLocalToken(address(tokenA), swapAmount);
+        uint256 pceReceived = pceToken.balanceOf(owner) - pceBalanceBefore;
+        pceToken.swapToLocalToken(address(tokenB), pceReceived);
+        uint256 indirectDepositA = pceToken.getDepositedPCETokens(address(tokenA));
+        uint256 indirectDepositB = pceToken.getDepositedPCETokens(address(tokenB));
+        vm.stopPrank();
+
+        assertEq(directDepositA, indirectDepositA, "A deposit must match between direct and indirect paths");
+        assertEq(directDepositB, indirectDepositB, "B deposit must match between direct and indirect paths");
+    }
+
+    function testRevertsWhenSourceDepositInsufficient() public {
+        // Force an under-collateralized A by directly editing the deposit slot, then attempt
+        // an inter-community swap whose PCE-equivalent exceeds A's recorded deposit.
+        vm.startPrank(owner);
+
+        // Drop A's recorded deposit to 1 ether while leaving owner's tokenA balance intact.
+        // localTokens is a mapping; LocalToken struct lays out (isExists, exchangeRate, depositedPCEToken).
+        // Compute slot for localTokens[address(tokenA)].depositedPCEToken (struct field offset 2 within mapping value).
+        bytes32 mappingSlot = bytes32(uint256(10)); // slot of `localTokens` per forge inspect storageLayout
+        bytes32 baseSlot = keccak256(abi.encode(address(tokenA), mappingSlot));
+        bytes32 depositedSlot = bytes32(uint256(baseSlot) + 2);
+        vm.store(address(pceToken), depositedSlot, bytes32(uint256(1 ether)));
+        assertEq(pceToken.getDepositedPCETokens(address(tokenA)), 1 ether);
+
+        // Owner holds 1000 ether of tokenA from createToken; try to swap 100 ether (PCE-equiv ≈ 100e18).
+        vm.expectRevert("Insufficient deposited PCE token reserve at source community");
+        tokenA.swapTokens(address(tokenB), 100 ether);
+
+        vm.stopPrank();
+    }
+
+    function testExecuteCallableOnlyByFromToken() public {
+        vm.expectRevert("Caller must be the from-side community token");
+        vm.prank(user1);
+        pceToken.executeInterCommunitySwap(address(tokenA), address(tokenB), user1, 1 ether, 1 ether);
+    }
+
+    function testExecuteRejectsSameToken() public {
+        vm.expectRevert("Same-token swap");
+        vm.prank(address(tokenA));
+        pceToken.executeInterCommunitySwap(address(tokenA), address(tokenA), user1, 1 ether, 1 ether);
+    }
+
+    function testExecuteRejectsUnregisteredFrom() public {
+        address fakeToken = address(0xdead);
+        vm.expectRevert("From token not registered");
+        vm.prank(fakeToken);
+        pceToken.executeInterCommunitySwap(fakeToken, address(tokenB), user1, 1 ether, 1 ether);
+    }
+
+    function testExecuteRejectsUnregisteredTo() public {
+        address fakeToken = address(0xdead);
+        vm.expectRevert("To token not registered");
+        vm.prank(address(tokenA));
+        pceToken.executeInterCommunitySwap(address(tokenA), fakeToken, user1, 1 ether, 1 ether);
+    }
+}


### PR DESCRIPTION
## Summary

- Implement [PIP-17: Deposit Migration on Inter-community Swap](https://github.com/peacecoin-protocol/PIPs/blob/pip-17/PIPs/pip-17.md) (PIPs PR [#12](https://github.com/peacecoin-protocol/PIPs/pull/12))
- New `PCEToken.executeInterCommunitySwap(fromToken, toToken, recipient, fromDisplayAmount, toDisplayAmount)` performs deposit migration **and** the destination-side mint atomically
- `PCECommunityToken.swapTokens` now delegates the destination-side mint + deposit migration to PCEToken via the new function (previous `to.mint(sender, ...)` call removed)
- Closes a latent bug: pre-PIP-17 `swapTokens` could not succeed end-to-end because `PCECommunityToken.mint` is gated to PCEToken; the source community token cannot satisfy that gate
- 8 new tests in `test/InterCommunitySwap.t.sol`; full suite (92 tests) green

## Why

`PCEToken.localTokens[community].depositedPCEToken` tracks the per-community PCE reserve. Three of the four reserve-affecting flows already maintain this accounting correctly (`swapToLocalToken`, `swapFromLocalToken`, `swapFeeFromLocalToken`). The fourth — direct community-to-community swap via `PCECommunityToken.swapTokens(toToken, amount)` — does not: raw supply was intended to move (burn on A, mint on B) but the per-community PCE reserve accounting did not move with it. In addition, the destination-side `to.mint(sender, targetTokenAmount)` call could not succeed at all because of the auth check in `PCECommunityToken.mint`, leaving the function non-functional in practice.

PIP-17 picks the minimal change that:

- makes `swapTokens` end-to-end functional, and
- keeps per-community deposit accounting consistent with the actual claim transferred,
- without restructuring the per-community reserve model into a global pool.

## Design

```
+-----------------------------+      +---------------------------------------+
| PCECommunityToken (source)  |      | PCEToken                              |
+-----------------------------+      +---------------------------------------+
| swapTokens(toToken, amount):|      | executeInterCommunitySwap(            |
|   ...validate...            |      |   fromToken, toToken,                 |
|   targetTokenAmount = ...   |      |   recipient,                          |
|   _burn(sender, raw)        | ---> |   fromDisplayAmount,                  |
|   pceToken.executeInter...  |      |   toDisplayAmount                     |
+-----------------------------+      | ):                                    |
                                     |   require(msg.sender == fromToken)    |
                                     |   require both registered, !=         |
                                     |   updateFactorIfNeeded()              |
                                     |   movedPceAmount = mulDiv(...)        |
                                     |   if movedPceAmount > 0:              |
                                     |     require(deposit >= movedPceAmount)|
                                     |     deposit[from] -= movedPceAmount   |
                                     |     deposit[to]   += movedPceAmount   |
                                     |   to.mint(recipient, toDisplayAmount) |
                                     |   emit Deposit...                     |
                                     +---------------------------------------+
```

`movedPceAmount` uses the same formula as `swapFromLocalToken` / `swapFeeFromLocalToken`:

```
movedPceAmount = mulDiv(
    mulDiv(fromDisplayAmount, INITIAL_FACTOR, localTokens[fromToken].exchangeRate),
    lastModifiedFactor,
    PCECommunityToken(fromToken).getCurrentFactor()
)
```

Direct A→B and indirect A→PCE→B now produce identical post-state on `localTokens[*].depositedPCEToken`.

## Files changed

| File | Change |
|---|---|
| `src/PCEToken.sol` | new event `DepositTransferredOnInterCommunitySwap`; new external function `executeInterCommunitySwap` (~40 LoC) |
| `src/PCECommunityToken.sol` | `swapTokens`: replace `to.mint(sender, targetTokenAmount)` with `pceToken.executeInterCommunitySwap(...)` |
| `test/InterCommunitySwap.t.sol` | new — 8 tests |

## Tests

```
$ forge test
...
Ran 8 tests for test/InterCommunitySwap.t.sol:InterCommunitySwapTest
[PASS] testDirectAndIndirectPathsProduceSameDeposits()
[PASS] testExecuteCallableOnlyByFromToken()
[PASS] testExecuteRejectsSameToken()
[PASS] testExecuteRejectsUnregisteredFrom()
[PASS] testExecuteRejectsUnregisteredTo()
[PASS] testInterCommunitySwapMovesDeposit()
[PASS] testRevertsWhenSourceDepositInsufficient()
[PASS] testTotalDepositInvariantUnderInterCommunitySwap()
Suite result: ok. 8 passed; 0 failed; 0 skipped

Ran 6 test suites: 92 tests passed, 0 failed, 0 skipped (92 total tests)
```

Coverage of the PIP's test cases:

| PIP test case | Covered by |
|---|---|
| Case 1: standard swap moves deposit | `testInterCommunitySwapMovesDeposit` |
| Case 2: direct == indirect post-state | `testDirectAndIndirectPathsProduceSameDeposits` |
| Case 3: insufficient source reverts | `testRevertsWhenSourceDepositInsufficient` |
| Case 4: caller authorization | `testExecuteCallableOnlyByFromToken` |
| Case 5: same-token guard | `testExecuteRejectsSameToken` |
| Case 6: unregistered token | `testExecuteRejectsUnregisteredFrom`, `testExecuteRejectsUnregisteredTo` |
| Case 8: protocol-wide deposit invariant | `testTotalDepositInvariantUnderInterCommunitySwap` |

## Backwards compatibility

- PCEToken: purely additive (new function, new event); no signature changes; no storage layout changes
- PCECommunityToken: `swapTokens`'s public signature is unchanged
- `swapFromLocalToken`, `swapToLocalToken`, `swapFeeFromLocalToken`, ARIGATO CREATION mint, decay, and all view functions: unchanged
- Pre-PIP-17 `swapTokens` was non-functional (reverted at the destination-side `mint` auth check), so no integration could have been relying on it for state mutation; PIP-17 makes the function functional

## Out of scope

- Backfilling pre-PIP-17 deposit drift (the on-chain state at upgrade is the new baseline)
- Restructuring to a global pool model (a separate alternative considered and explicitly rejected in favor of preserving per-community accounting)
- Treating inter-community swap as consumption of `swappedToPCEToday` (separable; would be a follow-up PIP)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
