### PR TITLE
fix(PIP-13): re-emit MetaTransactionFeeCollected alongside MetaTransactionFeeSwapped

### DIFF
--- a/src/PCECommunityToken.sol
+++ b/src/PCECommunityToken.sol
@@ -498,6 +498,7 @@ contract PCECommunityToken is
         _burn(from, rawFee);
         PCEToken pceToken = PCEToken(pceAddress);
         uint256 pceAmount = pceToken.swapFeeFromLocalToken(address(this), relayer, displayFee);
+        emit MetaTransactionFeeCollected(from, relayer, displayFee, rawFee);
         emit MetaTransactionFeeSwapped(from, relayer, displayFee, pceAmount);
         return pceAmount;
     }

--- a/test/PCE.t.sol
+++ b/test/PCE.t.sol
@@ -789,6 +789,12 @@ contract PCETest is Test {
         uint256 relayerCTBefore = token.balanceOf(relayer);
         uint256 user2CTBefore = token.balanceOf(user2);
 
+        uint256 displayFee = token.getMetaTransactionFee();
+        uint256 rawFee = token.displayBalanceToRawBalance(displayFee);
+
+        vm.expectEmit(true, true, false, true);
+        emit PCECommunityToken.MetaTransactionFeeCollected(signer, relayer, displayFee, rawFee);
+
         // Execute as relayer
         vm.prank(relayer);
         token.transferWithAuthorization(


### PR DESCRIPTION
## Summary

- PIP-13 (auto-swap meta-tx fee to PCE) silently dropped the existing `MetaTransactionFeeCollected` emit. The event's payer-side semantics (`from` was charged `displayFee` / `rawFee` community tokens, paid to relayer `to`) are still accurate — only the relayer's settlement asset changed.
- Re-emit `MetaTransactionFeeCollected` in `_collectFeeAsPCE` so existing indexers that track fee burden per payer continue to work. The new `MetaTransactionFeeSwapped` event remains for consumers that additionally need the PCE settlement amount.
- PIP-13 spec updated separately on https://github.com/peacecoin-protocol/PIPs/pull/8.

## Test plan

- [x] `forge build`
- [x] `forge test` (84 tests pass)
- [x] `testTransferWithAuthorizationFeeSwap` now asserts `MetaTransactionFeeCollected(from=signer, to=relayer, displayFee, rawFee)` is emitted

🤖 Generated with [Claude Code](https://claude.com/claude-code)