### PR TITLE
fix: deploy implementations via `new` and use UnsafeUpgrades in upgrade scripts

### DIFF
--- a/script/Upgrade.s.sol
+++ b/script/Upgrade.s.sol
@@ -14,6 +14,10 @@ contract Upgrade is BaseScript {
 
         Options memory opts;
         opts.unsafeSkipStorageCheck = true;
+        // PCECommunityToken legitimately links VoucherSystem/TokenValueOps/ArigatoCreation
+        // (external libraries) since v15. script/upgrade.sh validates linked-library
+        // upgrade safety externally before this script runs.
+        opts.unsafeAllow = "external-library-linking";
 
         Upgrades.upgradeProxy(pceTokenAddress, "PCEToken.sol:PCEToken", "", opts);
         Upgrades.upgradeBeacon(pceCommunityTokenAddress, "PCECommunityToken.sol:PCECommunityToken", opts);

--- a/script/Upgrade.s.sol
+++ b/script/Upgrade.s.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.30 <0.9.0;
 
-import { BaseScript } from "./Base.s.sol";
+import { Script } from "forge-std/Script.sol";
 import { PCEToken } from "../src/PCEToken.sol";
 import { PCECommunityToken } from "../src/PCECommunityToken.sol";
 import { UnsafeUpgrades } from "openzeppelin-foundry-upgrades/Upgrades.sol";
@@ -10,20 +10,28 @@ import { UnsafeUpgrades } from "openzeppelin-foundry-upgrades/Upgrades.sol";
 /// PCECommunityToken links external libraries (VoucherSystem / TokenValueOps / ArigatoCreation),
 /// which OZ's name-based Upgrades.upgrade*("Contract.sol:Name", opts) cannot deploy via vm.getCode.
 /// Deploy implementations directly via `new` (forge auto-handles library linking + CREATE2),
-/// then upgrade via the address-based variants.
+/// then upgrade via the address-based variants of UnsafeUpgrades.
 ///
 /// NOTE: production proxy/beacon are owned by the Polygon Timelock; this script is only usable
 /// when called from the Timelock (via governance proposal). For impl-only deploy used during
 /// proposal preparation, use script/DeployImpl.s.sol.
-contract Upgrade is BaseScript {
-    function run() public broadcast {
+///
+/// Required environment variable:
+/// - PRIVATE_KEY: deployer private key (must equal the Timelock for the upgrade calls to succeed)
+contract Upgrade is Script {
+    function run() external {
         address pceTokenAddress = 0xA4807a8C34353A5EA51aF073175950Cb6248dA7E;
         address pceCommunityTokenAddress = 0x6A73A610707C113F34D8B82498b6868e5f7FAA74;
+
+        uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
+        vm.startBroadcast(deployerPrivateKey);
 
         address pceTokenImpl = address(new PCEToken());
         address pceCommunityTokenImpl = address(new PCECommunityToken());
 
         UnsafeUpgrades.upgradeProxy(pceTokenAddress, pceTokenImpl, new bytes(0));
         UnsafeUpgrades.upgradeBeacon(pceCommunityTokenAddress, pceCommunityTokenImpl);
+
+        vm.stopBroadcast();
     }
 }

--- a/script/Upgrade.s.sol
+++ b/script/Upgrade.s.sol
@@ -2,24 +2,28 @@
 pragma solidity >=0.8.30 <0.9.0;
 
 import { BaseScript } from "./Base.s.sol";
+import { PCEToken } from "../src/PCEToken.sol";
+import { PCECommunityToken } from "../src/PCECommunityToken.sol";
+import { UnsafeUpgrades } from "openzeppelin-foundry-upgrades/Upgrades.sol";
 
-import { Upgrades, Options } from "openzeppelin-foundry-upgrades/Upgrades.sol";
-
-/// @dev See the Solidity Scripting tutorial: https://book.getfoundry.sh/tutorials/solidity-scripting
-/// Storage layout validation is performed by script/upgrade.sh before this script runs.
+/// @dev Storage layout validation is performed by script/upgrade.sh before this script runs.
+/// PCECommunityToken links external libraries (VoucherSystem / TokenValueOps / ArigatoCreation),
+/// which OZ's name-based Upgrades.upgrade*("Contract.sol:Name", opts) cannot deploy via vm.getCode.
+/// Deploy implementations directly via `new` (forge auto-handles library linking + CREATE2),
+/// then upgrade via the address-based variants.
+///
+/// NOTE: production proxy/beacon are owned by the Polygon Timelock; this script is only usable
+/// when called from the Timelock (via governance proposal). For impl-only deploy used during
+/// proposal preparation, use script/DeployImpl.s.sol.
 contract Upgrade is BaseScript {
     function run() public broadcast {
         address pceTokenAddress = 0xA4807a8C34353A5EA51aF073175950Cb6248dA7E;
         address pceCommunityTokenAddress = 0x6A73A610707C113F34D8B82498b6868e5f7FAA74;
 
-        Options memory opts;
-        opts.unsafeSkipStorageCheck = true;
-        // PCECommunityToken legitimately links VoucherSystem/TokenValueOps/ArigatoCreation
-        // (external libraries) since v15. script/upgrade.sh validates linked-library
-        // upgrade safety externally before this script runs.
-        opts.unsafeAllow = "external-library-linking";
+        address pceTokenImpl = address(new PCEToken());
+        address pceCommunityTokenImpl = address(new PCECommunityToken());
 
-        Upgrades.upgradeProxy(pceTokenAddress, "PCEToken.sol:PCEToken", "", opts);
-        Upgrades.upgradeBeacon(pceCommunityTokenAddress, "PCECommunityToken.sol:PCECommunityToken", opts);
+        UnsafeUpgrades.upgradeProxy(pceTokenAddress, pceTokenImpl, new bytes(0));
+        UnsafeUpgrades.upgradeBeacon(pceCommunityTokenAddress, pceCommunityTokenImpl);
     }
 }

--- a/script/UpgradeDEV.s.sol
+++ b/script/UpgradeDEV.s.sol
@@ -14,6 +14,10 @@ contract UpgradeDEV is BaseScript {
 
         Options memory opts;
         opts.unsafeSkipStorageCheck = true;
+        // PCECommunityToken legitimately links VoucherSystem/TokenValueOps/ArigatoCreation
+        // (external libraries) since v15. script/upgrade.sh validates linked-library
+        // upgrade safety externally before this script runs.
+        opts.unsafeAllow = "external-library-linking";
 
         Upgrades.upgradeProxy(pceTokenAddress, "PCEToken.sol:PCEToken", "", opts);
         Upgrades.upgradeBeacon(pceCommunityTokenAddress, "PCECommunityToken.sol:PCECommunityToken", opts);

--- a/script/UpgradeDEV.s.sol
+++ b/script/UpgradeDEV.s.sol
@@ -2,24 +2,24 @@
 pragma solidity >=0.8.30 <0.9.0;
 
 import { BaseScript } from "./Base.s.sol";
+import { PCEToken } from "../src/PCEToken.sol";
+import { PCECommunityToken } from "../src/PCECommunityToken.sol";
+import { UnsafeUpgrades } from "openzeppelin-foundry-upgrades/Upgrades.sol";
 
-import { Upgrades, Options } from "openzeppelin-foundry-upgrades/Upgrades.sol";
-
-/// @dev See the Solidity Scripting tutorial: https://book.getfoundry.sh/tutorials/solidity-scripting
-/// Storage layout validation is performed by script/upgrade.sh before this script runs.
+/// @dev Storage layout validation is performed by script/upgrade.sh before this script runs.
+/// PCECommunityToken links external libraries (VoucherSystem / TokenValueOps / ArigatoCreation),
+/// which OZ's name-based Upgrades.upgrade*("Contract.sol:Name", opts) cannot deploy via vm.getCode.
+/// Deploy implementations directly via `new` (forge auto-handles library linking + CREATE2),
+/// then upgrade via the address-based variants.
 contract UpgradeDEV is BaseScript {
     function run() public broadcast {
         address pceTokenAddress = 0x62Ef93EAa5bB3E47E0e855C323ef156c8E3D8913;
         address pceCommunityTokenAddress = 0xA9D965660dcF0fA73E709fd802e9DEF2d9b52952;
 
-        Options memory opts;
-        opts.unsafeSkipStorageCheck = true;
-        // PCECommunityToken legitimately links VoucherSystem/TokenValueOps/ArigatoCreation
-        // (external libraries) since v15. script/upgrade.sh validates linked-library
-        // upgrade safety externally before this script runs.
-        opts.unsafeAllow = "external-library-linking";
+        address pceTokenImpl = address(new PCEToken());
+        address pceCommunityTokenImpl = address(new PCECommunityToken());
 
-        Upgrades.upgradeProxy(pceTokenAddress, "PCEToken.sol:PCEToken", "", opts);
-        Upgrades.upgradeBeacon(pceCommunityTokenAddress, "PCECommunityToken.sol:PCECommunityToken", opts);
+        UnsafeUpgrades.upgradeProxy(pceTokenAddress, pceTokenImpl, new bytes(0));
+        UnsafeUpgrades.upgradeBeacon(pceCommunityTokenAddress, pceCommunityTokenImpl);
     }
 }

--- a/script/UpgradeDEV.s.sol
+++ b/script/UpgradeDEV.s.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.30 <0.9.0;
 
-import { BaseScript } from "./Base.s.sol";
+import { Script } from "forge-std/Script.sol";
 import { PCEToken } from "../src/PCEToken.sol";
 import { PCECommunityToken } from "../src/PCECommunityToken.sol";
 import { UnsafeUpgrades } from "openzeppelin-foundry-upgrades/Upgrades.sol";
@@ -10,16 +10,24 @@ import { UnsafeUpgrades } from "openzeppelin-foundry-upgrades/Upgrades.sol";
 /// PCECommunityToken links external libraries (VoucherSystem / TokenValueOps / ArigatoCreation),
 /// which OZ's name-based Upgrades.upgrade*("Contract.sol:Name", opts) cannot deploy via vm.getCode.
 /// Deploy implementations directly via `new` (forge auto-handles library linking + CREATE2),
-/// then upgrade via the address-based variants.
-contract UpgradeDEV is BaseScript {
-    function run() public broadcast {
+/// then upgrade via the address-based variants of UnsafeUpgrades.
+///
+/// Required environment variable:
+/// - PRIVATE_KEY: deployer private key (must own the DEV proxy / beacon)
+contract UpgradeDEV is Script {
+    function run() external {
         address pceTokenAddress = 0x62Ef93EAa5bB3E47E0e855C323ef156c8E3D8913;
         address pceCommunityTokenAddress = 0xA9D965660dcF0fA73E709fd802e9DEF2d9b52952;
+
+        uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
+        vm.startBroadcast(deployerPrivateKey);
 
         address pceTokenImpl = address(new PCEToken());
         address pceCommunityTokenImpl = address(new PCECommunityToken());
 
         UnsafeUpgrades.upgradeProxy(pceTokenAddress, pceTokenImpl, new bytes(0));
         UnsafeUpgrades.upgradeBeacon(pceCommunityTokenAddress, pceCommunityTokenImpl);
+
+        vm.stopBroadcast();
     }
 }


### PR DESCRIPTION
## Summary

The v16 DEV upgrade attempt failed in three stages, all rooted in the fact that since v15, `PCECommunityToken` legitimately links external libraries (`VoucherSystem`, `TokenValueOps`, `ArigatoCreation`) — and the existing scripts couldn't handle that path:

1. OZ's ffi-based `npx upgrades-core validate` rejected the linked libraries.
2. After bypassing that with `unsafeAllow=\"external-library-linking\"`, OZ's name-based `Upgrades.upgrade*(\"Contract.sol:Name\")` internally calls `vm.getCode(...)` which reverted with `no bytecode for contract; is it abstract or unlinked?` — there's no link step at that point.
3. With `--interactives 1` the broadcast required a controlling TTY for the password prompt and aborted with `Device not configured (os error 6)` from non-interactive environments.

## Fix

- Deploy implementations directly via `new PCEToken()` / `new PCECommunityToken()` (forge auto-handles library linking + CREATE2 deploy of any libraries that aren't already at the deterministic address), then call the address-based `UnsafeUpgrades.upgradeProxy` / `UnsafeUpgrades.upgradeBeacon`. Same pattern as `script/DeployImpl.s.sol`.
- Read `$PRIVATE_KEY` via `vm.envUint` instead of going through `BaseScript` + `--interactives 1`. Removes the TTY requirement.

Storage-layout safety is still validated externally by `script/upgrade.sh` before this script runs, so `UnsafeUpgrades` is intentional here — we've already done the validation OZ would have done.

Both `script/UpgradeDEV.s.sol` and `script/Upgrade.s.sol` updated.

New canonical invocation:

```
source .env && ./script/upgrade.sh script/UpgradeDEV.s.sol --broadcast --fork-url polygon
```

(No `--interactives 1`.)

## Test plan

- [x] `forge build` clean
- [x] DEV upgrade broadcast: `ONCHAIN EXECUTION COMPLETE & SUCCESSFUL.`
  - PCEToken proxy `0x62Ef93EAa5bB3E47E0e855C323ef156c8E3D8913` → impl `0x9fb1a0966bc5854f49152f423b3eaff931030c52` (`version() = \"1.0.15\"`)
  - PCECommunityToken beacon `0xA9D965660dcF0fA73E709fd802e9DEF2d9b52952` → impl `0x45723ec303591b8530faeffd746a6ff5341a7d70` (`version() = \"1.0.16\"`)
  - TokenValueOps redeployed at `0x9cb2774d0d5a9302220295e4f6af81345171db13` (CREATE2; ArigatoCreation / VoucherSystem unchanged so reused at existing addresses)

## Follow-ups

- `CLAUDE.md` documents the upgrade invocation with `--interactives 1` — should be updated post-merge to drop that flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)