### PR TITLE
Fix path-dependent community token decay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to the PCEToken and PCECommunityToken contracts are document
 Version numbering was previously tracked via separate contract files (e.g., PCETokenV2.sol).
 As of v11, a single file per contract is used and versioning is managed through git history.
 
+## v17
+- Fix `PCECommunityToken.getCurrentFactor` so multi-period community-token decay no longer depends on basis-point-truncated batched calculation
+- Evaluate the intermediate decay rate at WAD precision instead of basis-point precision
+- Reject `afterDecreaseBp > 10000` in `PCECommunityToken.setTokenSettings`
+
 ## v12
 - Fix fee drain in `transferFromWithAuthorization` — include fee in allowance check and spend
 - Add zero-amount transfer guard to `transferWithAuthorization` and `transferFromWithAuthorization`

--- a/src/PCECommunityToken.sol
+++ b/src/PCECommunityToken.sol
@@ -141,8 +141,8 @@ contract PCECommunityToken is
         // Apply multiple decay periods via O(log n) exponentiation
         uint256 times = elapsed / decreaseIntervalDays;
         uint256 factor = lastModifiedFactor;
-        uint256 rate = afterDecreaseBp;
-        uint256 base = BP_BASE;
+        uint256 rate = Math.mulDiv(afterDecreaseBp, INITIAL_FACTOR, BP_BASE);
+        uint256 base = INITIAL_FACTOR;
         uint256 n = times;
         while (n > 0) {
             if (n % 2 == 1) {
@@ -795,6 +795,7 @@ contract PCECommunityToken is
         override
         onlyOwner
     {
+        require(_afterDecreaseBp <= BP_BASE, "After decrease bp <= 10000");
         super.setTokenSettings(
             _decreaseIntervalDays,
             _afterDecreaseBp,
@@ -817,6 +818,6 @@ contract PCECommunityToken is
     }
 
     function version() public pure returns (string memory) {
-        return "1.0.16";
+        return "1.0.17";
     }
 }

--- a/test/PCE.t.sol
+++ b/test/PCE.t.sol
@@ -309,6 +309,174 @@ contract PCETest is Test {
         vm.stopPrank();
     }
 
+    function testCommunityTokenDecayUsesWadPrecisionForMultiplePeriods() public {
+        vm.startPrank(owner);
+
+        address[] memory incomeTargetTokens = new address[](0);
+        address[] memory outgoTargetTokens = new address[](0);
+
+        pceToken.createToken(
+            "Weekly Decay Token",
+            "WDT",
+            1000 ether,
+            1 ether,   // 1:1 dilution
+            7,         // decrease interval days
+            9980,      // after decrease bp (99.8%)
+            1000,      // max increase of total supply bp
+            500,       // max increase bp
+            1000,      // max usage bp
+            100,       // change bp
+            ExchangeAllowMethod.All,
+            ExchangeAllowMethod.All,
+            incomeTargetTokens,
+            outgoTargetTokens
+        );
+
+        address[] memory tokens_ = pceToken.getTokens();
+        PCECommunityToken weeklyToken = PCECommunityToken(tokens_[tokens_.length - 1]);
+
+        vm.warp(block.timestamp + 12 * 7 days);
+
+        uint256 currentFactor = weeklyToken.getCurrentFactor();
+        uint256 currentBpBatchedFactor = 976_128_000_000_000_000;
+        uint256 wadFactor = 976_262_247_894_715_033;
+
+        assertEq(currentFactor, wadFactor, "Should match WAD-precision 0.998^12");
+        assertGt(currentFactor, currentBpBatchedFactor, "Should not over-decay with BP-scale squaring");
+
+        vm.stopPrank();
+    }
+
+    function testBatchedDecayMatchesSequentialMaterializationWithinWadRounding() public {
+        vm.startPrank(owner);
+
+        address[] memory incomeTargetTokens = new address[](0);
+        address[] memory outgoTargetTokens = new address[](0);
+
+        pceToken.createToken(
+            "Batched Weekly Decay Token",
+            "BWDT",
+            1000 ether,
+            1 ether,   // 1:1 dilution
+            7,         // decrease interval days
+            9980,      // after decrease bp (99.8%)
+            1000,      // max increase of total supply bp
+            500,       // max increase bp
+            1000,      // max usage bp
+            100,       // change bp
+            ExchangeAllowMethod.All,
+            ExchangeAllowMethod.All,
+            incomeTargetTokens,
+            outgoTargetTokens
+        );
+
+        address[] memory tokensAfterBatch = pceToken.getTokens();
+        PCECommunityToken batchedToken = PCECommunityToken(tokensAfterBatch[tokensAfterBatch.length - 1]);
+
+        pceToken.createToken(
+            "Sequential Weekly Decay Token",
+            "SWDT",
+            1000 ether,
+            1 ether,   // 1:1 dilution
+            7,         // decrease interval days
+            9980,      // after decrease bp (99.8%)
+            1000,      // max increase of total supply bp
+            500,       // max increase bp
+            1000,      // max usage bp
+            100,       // change bp
+            ExchangeAllowMethod.All,
+            ExchangeAllowMethod.All,
+            incomeTargetTokens,
+            outgoTargetTokens
+        );
+
+        address[] memory tokensAfterSequential = pceToken.getTokens();
+        PCECommunityToken sequentialToken = PCECommunityToken(tokensAfterSequential[tokensAfterSequential.length - 1]);
+
+        uint256 startTime = block.timestamp;
+        for (uint256 i = 1; i <= 12; i++) {
+            vm.warp(startTime + i * 7 days);
+            sequentialToken.updateFactorIfNeeded();
+        }
+
+        uint256 batchedFactor = batchedToken.getCurrentFactor();
+        uint256 sequentialFactor = sequentialToken.getCurrentFactor();
+
+        assertApproxEqAbs(
+            batchedFactor,
+            sequentialFactor,
+            10,
+            "Batched and sequential decay should match within WAD rounding"
+        );
+
+        vm.stopPrank();
+    }
+
+    function testSetTokenSettingsRejectsAfterDecreaseAboveBpBase() public {
+        address[] memory incomeTargetTokens = new address[](0);
+        address[] memory outgoTargetTokens = new address[](0);
+
+        vm.expectRevert(bytes("After decrease bp <= 10000"));
+        token.setTokenSettings(
+            1,
+            10_001,
+            1000,
+            500,
+            1000,
+            100,
+            ExchangeAllowMethod.All,
+            ExchangeAllowMethod.All,
+            incomeTargetTokens,
+            outgoTargetTokens
+        );
+    }
+
+    function testCommunityTokenDoesNotDecayWhenIntervalIsZero() public {
+        address[] memory incomeTargetTokens = new address[](0);
+        address[] memory outgoTargetTokens = new address[](0);
+
+        token.setTokenSettings(
+            0,
+            9980,
+            1000,
+            500,
+            1000,
+            100,
+            ExchangeAllowMethod.All,
+            ExchangeAllowMethod.All,
+            incomeTargetTokens,
+            outgoTargetTokens
+        );
+
+        uint256 factorBefore = token.getCurrentFactor();
+        vm.warp(block.timestamp + 365 days);
+
+        assertEq(token.getCurrentFactor(), factorBefore, "Interval 0 should disable decay");
+    }
+
+    function testCommunityTokenFullRetentionDoesNotDecay() public {
+        address[] memory incomeTargetTokens = new address[](0);
+        address[] memory outgoTargetTokens = new address[](0);
+
+        token.setTokenSettings(
+            7,
+            10_000,
+            1000,
+            500,
+            1000,
+            100,
+            ExchangeAllowMethod.All,
+            ExchangeAllowMethod.All,
+            incomeTargetTokens,
+            outgoTargetTokens
+        );
+
+        uint256 factorBefore = token.getCurrentFactor();
+        vm.warp(block.timestamp + 52 * 7 days);
+
+        assertEq(token.getCurrentFactor(), factorBefore, "10000 bp should retain full factor");
+    }
+
     function testNewMintAfterDepreciationShowsCorrectBalance() public {
         vm.startPrank(owner);
 
@@ -352,7 +520,7 @@ contract PCETest is Test {
 
     function testVersion() public view {
         assertEq(pceToken.version(), "1.0.15");
-        assertEq(token.version(), "1.0.16");
+        assertEq(token.version(), "1.0.17");
     }
 
     // --- PIP-16: Owner-controlled token value operations tests ---


### PR DESCRIPTION
## Summary

- Implement [PIP-21: Path-Consistent Community Token Decay Factor](https://github.com/peacecoin-protocol/PIPs/pull/16)
- Fix the current behavior where multi-period community-token decay can differ depending on whether factors are materialized period-by-period or computed in one batched `getCurrentFactor()` call.
- Convert `afterDecreaseBp` to WAD precision before exponentiation-by-squaring, removing the basis-point-truncated batched path.
- Add `afterDecreaseBp <= 10000` validation to direct `setTokenSettings()` updates.
- Bump `PCECommunityToken.version()` to `1.0.17` and document the v17 change.
- Add regression tests for batched-vs-sequential path consistency, WAD-precision multi-period decay, invalid settings, disabled decay, and full-retention settings.

## Context

This addresses the mismatch discussed in #45. The core issue is not only that the current batched BP-scale path can over-decay; it is that the decay result can depend on interaction cadence. A token whose factor is materialized every period can end up with a different factor from a token with the same settings and elapsed time whose factor is computed after several periods in one call.

Related proposal PR: [peacecoin-protocol/PIPs#16](https://github.com/peacecoin-protocol/PIPs/pull/16)

## Design

```solidity
// before
uint256 rate = afterDecreaseBp;
uint256 base = BP_BASE;

// after
uint256 rate = Math.mulDiv(afterDecreaseBp, INITIAL_FACTOR, BP_BASE);
uint256 base = INITIAL_FACTOR;
```

This keeps the existing O(log n) exponentiation-by-squaring path while moving intermediate rate squaring to the same WAD scale used by `lastModifiedFactor`. In effect, the fix removes the material BP-scale path dependence and improves intermediate precision.

## Tests

- `testBatchedDecayMatchesSequentialMaterializationWithinWadRounding`
- `testCommunityTokenDecayUsesWadPrecisionForMultiplePeriods`
- `testSetTokenSettingsRejectsAfterDecreaseAboveBpBase`
- `testCommunityTokenDoesNotDecayWhenIntervalIsZero`
- `testCommunityTokenFullRetentionDoesNotDecay`
- `testVersion`

## Validation

- `git diff --check`
- `forge test` — 81 passed
- `forge build --sizes` — `PCECommunityToken` runtime margin: 849 bytes
